### PR TITLE
docs: rewrite demo guide as technical walkthrough

### DIFF
--- a/docs/demo-console.mdx
+++ b/docs/demo-console.mdx
@@ -7,87 +7,58 @@ sidebar:
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-This section walks through configuring Client-Side Defense in the F5 XC Console. For the demo, CSD is already enabled on the demo application — use this walkthrough to show customers how simple the setup process is.
+CSD is already enabled on the demo application. This section shows the configuration screens.
 
-## Navigating to Client-Side Defense
+## Navigate to Client-Side Defense
 
 <Steps>
 1. Log in to the **F5 Distributed Cloud Console**
-2. From the home page, select **Client-Side Defense** under **Common Services**
-3. The CSD dashboard opens, showing an overview of all protected domains
+2. Select **Client-Side Defense** under **Common Services**
 </Steps>
 
 {/* ![CSD Dashboard](/csd/images/csd-dashboard.png) */}
 
-<Aside type="tip" title="Talking Point">
-"Client-Side Defense is a platform service — it works across all your HTTP load balancers and application namespaces. You configure it once and it protects every page served through your F5 XC infrastructure."
-</Aside>
+## Domain Configuration
 
-## Adding a Protected Domain
+The CSD configuration page lists protected domains. Each domain has a JavaScript injection scope:
 
-To protect a new domain with CSD:
+| Mode | Description |
+| --- | --- |
+| **All pages** | CSD script injected on every page |
+| **All pages with exceptions** | Exclude specific URL paths |
+| **Custom** | Inject only on specified paths |
 
-<Steps>
-1. Click **Add domain** on the CSD configuration page
-2. Enter the domain name (e.g., `botdemo.sales-demo.f5demos.com`)
-3. Select the JavaScript injection scope:
-   - **All pages** — Inject the CSD monitoring script on every page (recommended for demos)
-   - **All pages with exceptions** — Exclude specific URL paths
-   - **Custom** — Only inject on specific URL paths
-4. Save the configuration
-</Steps>
+The demo domain (`botdemo.sales-demo.f5demos.com`) is set to **All pages**.
 
 <Aside type="note">
-For the demo environment, CSD is already configured to monitor all pages on the demo domain. Use this walkthrough to explain the configuration options without making changes.
+Do not modify the demo domain configuration. Review the settings in read-only mode.
 </Aside>
 
-## JavaScript Injection Options
+## HTTP Load Balancer Method
 
-CSD works by injecting a lightweight JavaScript snippet into protected pages. Explain the three injection modes:
-
-| Mode | Use Case |
-| --- | --- |
-| **All pages** | Broadest protection — monitors every page served by the load balancer |
-| **All pages with exceptions** | Exclude known-safe paths (e.g., static asset directories, health check endpoints) |
-| **Custom rules** | Target specific pages (e.g., only payment and login pages) for minimal performance footprint |
-
-<Aside type="tip" title="Talking Point">
-"Most customers start with 'All pages' to get full visibility, then fine-tune with exceptions once they understand their script landscape. The monitoring script is very lightweight — typically under 50 KB — so the performance impact is negligible."
-</Aside>
-
-## Configuring via HTTP Load Balancer
-
-CSD can also be enabled directly on an HTTP Load Balancer configuration:
+CSD can also be enabled on an HTTP Load Balancer:
 
 <Steps>
-1. Navigate to **Multi-Cloud App Connect** → **HTTP Load Balancers**
-2. Edit the load balancer serving the demo application
-3. In the **Common Security Controls** section, find **Client-Side Defense**
-4. Toggle CSD to **Enabled**
-5. Configure the JavaScript insertion settings (same options as above)
-6. Save and apply the configuration
+1. Navigate to **Multi-Cloud App Connect** &rarr; **HTTP Load Balancers**
+2. Edit the load balancer serving the application
+3. Under **Common Security Controls**, find **Client-Side Defense**
+4. Toggle to **Enabled** and configure injection settings
 </Steps>
 
 {/* ![Load Balancer CSD Configuration](/csd/images/csd-lb-config.png) */}
 
-<Aside type="note">
-Both configuration methods (CSD tile and HTTP LB settings) achieve the same result. The CSD tile provides a centralized view across all domains, while the HTTP LB method is useful when configuring CSD as part of a broader application delivery setup.
-</Aside>
+Both the CSD tile and the HTTP LB configuration produce the same result.
 
-## Verifying JavaScript Injection
-
-After CSD is enabled, verify the monitoring script is present on protected pages:
+## Verify Script Injection
 
 <Steps>
 1. Open the demo application in Chrome
 2. Press **F12** to open DevTools
 3. Go to the **Elements** tab
-4. Search for `f5csd` in the HTML source
-5. Confirm the CSD JavaScript snippet is injected in the page
+4. Search for `f5csd` in the HTML
+5. Confirm a `<script>` tag referencing the CSD library is present
 </Steps>
 
-You should see a `<script>` tag referencing the F5 CSD monitoring library. This confirms that CSD is active and monitoring scripts on the page.
-
 <Aside type="caution">
-If the script is not present, check that the domain configuration is saved and that you are accessing the application through the F5 XC load balancer (not directly to the origin server).
+If the script is not present, verify the domain is configured and you are accessing the application through the F5 XC load balancer.
 </Aside>

--- a/docs/demo-detection.mdx
+++ b/docs/demo-detection.mdx
@@ -7,137 +7,79 @@ sidebar:
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-This is the core of the demo — showing CSD's detection, analysis, and mitigation capabilities. Walk the customer through the dashboard, drill into suspicious findings, and demonstrate one-click mitigation.
+## Dashboard
 
-## Dashboard Overview
-
-Navigate to the **Client-Side Defense** dashboard in the F5 XC Console. The dashboard provides a high-level summary of:
+Navigate to the **Client-Side Defense** dashboard. The summary shows:
 
 {/* ![CSD Dashboard Overview](/csd/images/csd-dashboard.png) */}
 
-- **Total monitored scripts** — Number of unique scripts detected across all protected pages
-- **Suspicious domains** — Domains flagged by ML analysis as potentially malicious
-- **Protected domains** — Number of domains with CSD enabled
-- **Recent alerts** — Latest suspicious activity notifications
-
-<Aside type="tip" title="Talking Point">
-"This single dashboard gives you visibility into every script running on your protected web properties. Most customers are surprised by the number of scripts they discover — it is common to find 50 to 100 scripts on a single page, many of which were added by third-party tag managers without the security team's knowledge."
-</Aside>
+- Total monitored scripts
+- Suspicious domains flagged
+- Protected domains count
+- Recent alerts
 
 ## Script Inventory
 
-Click into the **script inventory** to see all detected scripts:
+Open the script inventory to view all detected scripts.
 
 {/* ![Script Inventory](/csd/images/csd-script-list.png) */}
 
-For each script, CSD shows:
-
 | Field | Description |
 | --- | --- |
-| **Script URL** | Full URL of the detected JavaScript file |
-| **Source domain** | The domain hosting the script |
-| **First seen** | When CSD first detected the script |
-| **Last seen** | Most recent detection |
-| **Risk score** | ML-assigned risk level (low, medium, high) |
+| **Script URL** | Full URL of the JavaScript file |
+| **Source domain** | Domain hosting the script |
+| **First seen / Last seen** | Detection timestamps |
+| **Risk score** | ML-assigned level: low, medium, high |
 | **Status** | Monitored, alerted, or mitigated |
 
 <Steps>
-1. Sort the list by **Risk score** to surface the most suspicious scripts first
-2. Click on a high-risk script to view its details
-3. Show the ML analysis breakdown — what factors contributed to the risk score
+1. Sort by **Risk score** (high first)
+2. Click a high-risk script to view its detail page
+3. Review the ML analysis breakdown showing risk factors
 </Steps>
-
-<Aside type="tip" title="Talking Point">
-"CSD does not just list scripts — it analyzes their behavior. The risk score is based on machine learning models that evaluate what the script does, where it sends data, and how it compares to known malicious patterns. This is not a static blocklist — it is behavioral analysis."
-</Aside>
 
 ## Suspicious Domain Analysis
 
-When CSD flags a domain as suspicious, click into the domain details to show:
+Select a flagged domain to view:
 
-- **Why it was flagged** — ML analysis summary explaining the risk factors
-- **Associated scripts** — Which scripts communicate with this domain
-- **Data flow analysis** — What type of data is being sent to the domain
-- **Domain reputation** — External threat intelligence correlation
-
-<Aside type="caution" title="Key Message">
-Emphasize that CSD detects **new and unknown threats** — not just known-bad domains. The ML models identify suspicious behavior patterns even when the domain has no prior reputation data.
-</Aside>
+- ML analysis summary and risk factors
+- Associated scripts communicating with the domain
+- Data flow analysis (what data is sent)
+- Domain reputation from threat intelligence
 
 ## Network Visualization
-
-The network visualization is one of CSD's most visually compelling features:
 
 {/* ![Network Visualization](/csd/images/csd-network-view.png) */}
 
 <Steps>
-1. Navigate to the **Network** view from the CSD dashboard
-2. Show the interactive graph of relationships between pages, scripts, and external domains
-3. Highlight data flows — arrows indicate where scripts are sending data
-4. Click on nodes to drill into specific scripts or domains
-5. Point out any connections to suspicious or unknown domains
+1. Open the **Network** view from the CSD dashboard
+2. Review the graph showing pages, scripts, and external domains
+3. Arrows indicate data flow direction between nodes
+4. Click nodes to drill into specific scripts or domains
 </Steps>
-
-<Aside type="tip" title="Talking Point">
-"This visualization shows the complete picture of client-side activity. You can see exactly which scripts are loaded on which pages, where they are hosted, and where they send data. For most customers, this is the first time they have ever had this level of visibility into their client-side attack surface."
-</Aside>
 
 ## Alert Configuration
 
-CSD can notify your security team when suspicious activity is detected:
-
 <Steps>
-1. Navigate to the **Alerts** configuration section
-2. Show the alert rule setup — trigger conditions, severity thresholds
-3. Demonstrate the email notification format
-4. Explain that alerts can be configured per-domain or globally
+1. Open the **Alerts** configuration section
+2. Review trigger conditions: new suspicious domain, risk score threshold, new script detected, behavior change
+3. Alerts can be scoped per-domain or globally
+4. Email notifications are sent to the configured alert receiver
 </Steps>
 
-Alerts can be triggered by:
-
-- New suspicious domain detected
-- Script risk score exceeds threshold
-- New script detected on a protected page
-- Script behavior change detected
-
 <Aside type="note">
-For the demo, show a sample alert email if available. Real-time alerts depend on actual suspicious activity being detected, which may not happen during a live demo. Having a screenshot of a sample alert ready is recommended.
+Real-time alerts depend on suspicious activity being detected. Have a screenshot of a sample alert email ready if live activity is not available during the demo.
 </Aside>
 
-## One-Click Mitigation
-
-This is the payoff moment — show how easy it is to block a malicious script:
+## Mitigation
 
 {/* ![Mitigation Action](/csd/images/csd-mitigation.png) */}
 
 <Steps>
-1. Select a suspicious script from the inventory or alert
-2. Click the **Mitigate** button
-3. Confirm the mitigation action
-4. Show that the script status changes from **Alert** to **Mitigated**
-5. Explain that the CSD JavaScript will now block this script from executing on protected pages
+1. Select a suspicious script from the inventory
+2. Click **Mitigate**
+3. Confirm the action
+4. The script status changes from **Alert** to **Mitigated**
 </Steps>
 
-<Aside type="tip" title="Talking Point">
-"This is one-click mitigation — no code changes, no deployments, no waiting for a maintenance window. The security team can block a malicious script in seconds, and the change takes effect immediately on the next page load. This is the speed you need when responding to a Magecart-style attack."
-</Aside>
-
-Key points about mitigation:
-
-- **Immediate effect** — Blocked scripts are prevented from executing on the next page load
-- **No application changes** — Mitigation happens at the CSD layer, not in application code
-- **Reversible** — If a script is incorrectly blocked, the mitigation can be removed instantly
-- **Granular control** — Block individual scripts or entire domains
-
-## Page Tamper Detection
-
-For customers concerned about PCI DSS compliance, highlight CSD's page tamper detection:
-
-- **Payment page monitoring** — CSD specifically tracks scripts on pages that handle payment data
-- **Script authorization** — Maintain an authorized script inventory for payment pages
-- **Tamper alerts** — Immediate notification when unauthorized scripts appear on payment pages
-- **PCI DSS 6.4.3 compliance** — Continuous monitoring satisfies the requirement for script inventory and authorization on payment pages
-
-<Aside type="caution" title="Key Message">
-"PCI DSS 4.0 Requirement 6.4.3 is not optional — it mandates that organizations monitor and authorize all scripts on payment pages. CSD provides this capability out of the box, with continuous monitoring and a clear audit trail."
-</Aside>
+Mitigated scripts are blocked from executing on the next page load. Mitigation is reversible — removing the mitigation restores script execution.

--- a/docs/demo-website.mdx
+++ b/docs/demo-website.mdx
@@ -5,84 +5,37 @@ sidebar:
   label: Application Walkthrough
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Steps } from "@astrojs/starlight/components";
 
-This section walks through the demo application to set the scene before showing CSD in the console. The goal is to help the customer understand **what is at risk** before you show them the solution.
+## Open the Demo Application
 
-## Accessing the Demo Application
-
-Open the Juice Shop demo application in your browser:
-
-**`https://botdemo.sales-demo.f5demos.com`**
+Navigate to `https://botdemo.sales-demo.f5demos.com`. This is a Juice Shop e-commerce application with product listings, user accounts, and a checkout flow.
 
 {/* ![Juice Shop home page](/csd/images/demo-app-home.png) */}
 
-The application is a modern e-commerce storefront with:
+## Review Pages with Form Inputs
 
-- Product catalog with search and filtering
-- User registration and login
-- Shopping cart and checkout flow
-- Customer feedback and review forms
-
-<Aside type="tip" title="Talking Point">
-"This is a typical e-commerce application — it could be any of your customer-facing web properties. It loads JavaScript from multiple sources to handle payments, analytics, and interactive features. Let's look at what that means from a security perspective."
-</Aside>
-
-## Identifying the Attack Surface
-
-Walk the customer through the pages that handle sensitive data:
+Browse pages that collect sensitive data:
 
 <Steps>
-1. **Login page** — Collects username and password credentials
+1. **Login page** — username and password fields
 
    {/* ![Login form](/csd/images/demo-app-login.png) */}
 
-2. **Registration page** — Collects email, password, and security question answers
-
-3. **Payment / checkout flow** — Collects credit card numbers, CVVs, and billing addresses
-
-4. **Customer feedback forms** — Collects personal information and free-text input
+2. **Registration page** — email, password, security question
+3. **Payment / checkout** — credit card number, CVV, billing address
+4. **Customer feedback** — personal information and free-text fields
 </Steps>
 
-Every one of these forms is a potential target for formjacking attacks. A malicious script injected into any of these pages can silently copy form data as the user types and send it to an attacker-controlled domain.
+These are the pages CSD monitors for unauthorized script activity.
 
-<Aside type="caution" title="Key Message">
-Server-side security (WAF, API protection, DDoS mitigation) cannot see what happens inside the browser. A compromised third-party script executes in the user's browser session with full access to the DOM — including form fields, cookies, and session tokens.
-</Aside>
-
-## What Happens Without Protection
-
-Explain the attack scenario to the customer:
-
-1. **The attacker compromises a third-party script** — This could be an analytics library, a tag manager, or any externally hosted JavaScript
-2. **The compromised script is loaded by the application** — Because it is included via a legitimate `<script>` tag, the browser trusts it completely
-3. **The script reads sensitive form data** — It attaches event listeners to input fields and copies values as the user types
-4. **Data is exfiltrated to an external domain** — The script sends the stolen data to an attacker-controlled server, often disguised as a normal analytics or tracking request
-
-<Aside type="tip" title="Talking Point">
-"The scary part is that nothing looks wrong to the user. The page works normally, the form submits successfully, and the order goes through. Meanwhile, the attacker has a copy of the credit card number. This is why Magecart attacks can persist for months before detection."
-</Aside>
-
-## Browser DevTools (Optional)
-
-For a more technical audience, you can show the scripts currently loaded on the page using Chrome DevTools.
+## Inspect Loaded Scripts (Optional)
 
 <Steps>
 1. Press **F12** to open Chrome DevTools
-2. Navigate to the **Sources** tab
-3. Expand the page's script sources to show all loaded JavaScript files
-4. Point out scripts loaded from third-party domains
+2. Open the **Sources** tab
+3. Expand the script tree to see all loaded JavaScript files
+4. Note scripts loaded from third-party domains
 </Steps>
 
-<Aside type="note">
-This step is optional and works best with technical audiences (security engineers, developers). For executive audiences, the narrative about the attack scenario is usually more effective than showing raw DevTools output.
-</Aside>
-
-Highlight that:
-
-- Multiple scripts are loaded from external domains
-- Some scripts dynamically load additional scripts at runtime
-- There is no built-in browser mechanism to control what these scripts can access or where they can send data
-- Traditional Content Security Policy (CSP) headers are brittle and difficult to maintain for complex applications
-
-With the attack surface established, you are ready to show how CSD provides visibility and control over these scripts.
+Multiple external scripts load on each page. Some dynamically load additional scripts at runtime. CSD tracks all of these.

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -4,74 +4,30 @@ sidebar:
   order: 1
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Steps } from "@astrojs/starlight/components";
 
-## The Client-Side Threat Landscape
+This guide walks through a Client-Side Defense (CSD) demonstration using a Juice Shop e-commerce application as the protected site. CSD is already enabled on the demo environment.
 
-Modern web applications rely on dozens of third-party scripts — analytics, tag managers, payment processors, chat widgets, and more. Each script is a potential entry point for attackers.
-
-**Formjacking** and **Magecart-style attacks** inject malicious JavaScript into web pages to skim credit card numbers, credentials, and personal data directly from the browser. These attacks are invisible to traditional server-side security controls because the malicious code executes entirely in the end user's browser.
-
-Real-world impact:
-
-- **British Airways** — 380,000 payment cards stolen via a modified checkout script
-- **Ticketmaster** — Customer payment data exfiltrated through a compromised third-party chat widget
-- **PCI DSS 4.0 (Requirement 6.4.3)** — Now mandates monitoring and authorization of all scripts on payment pages
-
-<Aside type="tip" title="Talking Point">
-Ask the customer: "How many third-party scripts run on your checkout page? Do you know what each one does?" Most organizations cannot answer this question — which is exactly the problem CSD solves.
-</Aside>
-
-## What is Client-Side Defense?
-
-F5 Distributed Cloud **Client-Side Defense (CSD)** is a browser-side monitoring and mitigation service that protects web applications against client-side attacks. CSD works by:
-
-1. **Injecting a lightweight monitoring script** into protected web pages
-2. **Analyzing all JavaScript activity** in the browser using machine learning
-3. **Alerting and mitigating** suspicious behavior with a single click
-
-CSD provides visibility into every script running on your pages — including scripts loaded dynamically by other scripts — and uses ML-based analysis to detect anomalous behavior such as unauthorized data exfiltration.
-
-## How It Works
-
-CSD follows a three-phase model:
+## Demo Flow
 
 ```mermaid
 flowchart LR
-    A["Detection<br/>Monitor all scripts<br/>on protected pages"] --> B["Alerting<br/>ML analysis flags<br/>suspicious behavior"]
-    B --> C["Mitigation<br/>One-click block of<br/>malicious scripts"]
-    style A fill:#0072c6,color:#fff
-    style B fill:#f5a623,color:#fff
-    style C fill:#d0021b,color:#fff
+    A["Application\nWalkthrough"] --> B["CSD\nConfiguration"]
+    B --> C["Detection &\nMitigation"]
 ```
 
-| Phase | What Happens |
-| --- | --- |
-| **Detection** | The CSD JavaScript monitors all scripts executing in the browser and reports back to the F5 XC platform |
-| **Alerting** | Machine learning models analyze script behavior, network connections, and data flow patterns to flag suspicious activity |
-| **Mitigation** | Security teams review alerts and can block malicious scripts with a single click — no code changes or deployments required |
-
-## Key Capabilities
-
-- **Script Inventory** — Complete visibility into every script running on protected pages, including dynamically loaded scripts
-- **Suspicious Domain Detection** — ML-based identification of domains involved in data exfiltration or unauthorized communication
-- **Network Visualization** — Interactive graph showing relationships between scripts, domains, and data flows
-- **One-Click Mitigation** — Block malicious scripts instantly without application changes
-- **PCI DSS 6.4.3 Compliance** — Continuous monitoring and authorization of payment page scripts
-- **Email Alerts** — Configurable notifications when new suspicious activity is detected
-
-## Demo Scenario
-
-In this sales demo, you will use an **OWASP Juice Shop** instance — a deliberately vulnerable e-commerce application — to demonstrate CSD's capabilities. You will:
-
 <Steps>
-1. Explore the demo application and identify its attack surface
-2. Enable CSD protection in the F5 XC Console
-3. Review detected scripts and suspicious domains on the CSD dashboard
-4. Walk through the network visualization and alert configuration
-5. Demonstrate one-click mitigation of a suspicious script
+1. Open the demo application and review pages with form inputs
+2. Navigate CSD configuration in the XC Console
+3. Review the script inventory and dashboard
+4. Inspect suspicious domains and network visualization
+5. Mitigate a flagged script
 </Steps>
 
-<Aside type="note">
-This demo uses a pre-configured environment. The Juice Shop application and CSD configuration are already deployed — you just need console access to walk through the demo flow.
-</Aside>
+## Demo Environment
+
+| Component | Detail |
+| --- | --- |
+| **Demo application** | Juice Shop at `https://botdemo.sales-demo.f5demos.com` |
+| **CSD status** | Pre-configured and monitoring all pages |
+| **Console** | F5 Distributed Cloud Console with CSD permissions |

--- a/docs/prerequisites.mdx
+++ b/docs/prerequisites.mdx
@@ -4,67 +4,19 @@ sidebar:
   order: 2
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
-Before starting the demo, confirm that you have the following ready.
+## Requirements
 
-## Console Access
-
-You need access to the **F5 Distributed Cloud Console** with permissions to view and manage Client-Side Defense settings.
-
-<Steps>
-1. Log in to the F5 XC Console
-2. Confirm you can navigate to **Client-Side Defense** under Common Services
-3. Verify your account has permissions to view CSD dashboards and configuration
-</Steps>
+| Item | Detail |
+| --- | --- |
+| **F5 XC Console** | Account with CSD permissions under Common Services |
+| **Demo application** | `https://botdemo.sales-demo.f5demos.com` loads in browser |
+| **Browser** | Chrome recommended (DevTools used in later steps) |
+| **Email** | Access to the configured CSD alert receiver (optional) |
 
 <Aside type="caution">
-If you do not see the Client-Side Defense tile under Common Services, contact your tenant administrator to enable CSD for your account.
+If the Client-Side Defense tile is not visible under Common Services, contact your tenant administrator.
 </Aside>
 
-## Demo Application
-
-The demo uses an OWASP Juice Shop instance accessible at:
-
-**`https://botdemo.sales-demo.f5demos.com`**
-
-<Steps>
-1. Open the URL in your browser and confirm the application loads
-2. Verify you can see the product listing page
-3. Navigate to the login page to confirm forms are accessible
-</Steps>
-
-<Aside type="note">
-The demo application is shared across the sales engineering team. Do not modify its configuration or data. If the application is unavailable, check with the demo infrastructure team.
-</Aside>
-
-## Browser Setup
-
-**Google Chrome** is recommended for this demo.
-
-- Use Chrome DevTools (F12) to inspect network requests and script loading during the optional technical deep-dive sections
-- Ensure you have no browser extensions that block JavaScript execution (disable ad blockers temporarily if needed)
-- Consider using a clean browser profile or incognito window for a consistent demo experience
-
-## Email Verification
-
-CSD can send email alerts when suspicious activity is detected. If you plan to demonstrate the alerting workflow:
-
-<Steps>
-1. Confirm you have access to the email address configured as the CSD alert receiver
-2. Check that alerts from F5 XC are not being caught by spam filters
-3. Have your email client open in a separate tab during the demo
-</Steps>
-
-## Demo Checklist
-
-| Item | Status |
-| --- | --- |
-| F5 XC Console access with CSD permissions | &#9744; |
-| Demo application loads at the public URL | &#9744; |
-| Chrome browser with DevTools available | &#9744; |
-| Email alert receiver verified (optional) | &#9744; |
-
-<Aside type="tip" title="Talking Point">
-Run through this checklist 15 minutes before your demo. There is nothing worse than discovering access issues in front of a customer.
-</Aside>
+Confirm the demo application loads and you can reach the login page before proceeding.

--- a/docs/references.mdx
+++ b/docs/references.mdx
@@ -4,34 +4,24 @@ sidebar:
   order: 6
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+## Documentation
 
-Curated resources for deeper exploration of F5 Distributed Cloud Client-Side Defense.
-
-## Official Documentation
-
-- [About Client-Side Defense](https://docs.cloud.f5.com/docs-v2/client-side-defense/concepts/about-csd) — Concepts and architecture overview
-- [Configure Client-Side Defense](https://docs.cloud.f5.com/docs-v2/client-side-defense/how-tos/configure-csd) — Step-by-step configuration guide
-- [Client-Side Defense Landing Page](https://docs.cloud.f5.com/docs-v2/client-side-defense) — All CSD documentation
+- [About Client-Side Defense](https://docs.cloud.f5.com/docs-v2/client-side-defense/concepts/about-csd) — Concepts and architecture
+- [Configure Client-Side Defense](https://docs.cloud.f5.com/docs-v2/client-side-defense/how-tos/configure-csd) — Configuration guide
+- [Client-Side Defense](https://docs.cloud.f5.com/docs-v2/client-side-defense) — All CSD documentation
 
 ## Product Resources
 
-- [F5 Client-Side Defense Product Page](https://www.f5.com/products/distributed-cloud-services/client-side-defense#resources) — Product overview, data sheets, and additional resources
+- [F5 Client-Side Defense](https://www.f5.com/products/distributed-cloud-services/client-side-defense#resources) — Product page and data sheets
 
-## Video Resources
+## Video
 
-- [Client-Side Defense Demo](https://www.youtube.com/watch?v=esQtt2Ek3Ug) — Video walkthrough of CSD capabilities
+- [Client-Side Defense Demo](https://www.youtube.com/watch?v=esQtt2Ek3Ug) — Video walkthrough
 
-## Related Sales Demos
+## Related Demo Guides
 
-Explore other F5 Distributed Cloud sales demo guides:
-
-- [WAF Sales Demo](https://f5xc-salesdemos.github.io/waf/) — Web Application Firewall
-- [Bot Defense Sales Demo](https://f5xc-salesdemos.github.io/bot-standard/) — Bot Standard Protection
-- [Advanced Bot Defense Sales Demo](https://f5xc-salesdemos.github.io/bot-advanced/) — Bot Advanced Protection
-- [API Protection Sales Demo](https://f5xc-salesdemos.github.io/api-protection/) — API Discovery and Protection
-- [DDoS Sales Demo](https://f5xc-salesdemos.github.io/ddos/) — DDoS Mitigation
-
-<Aside type="tip">
-Bookmark this page for quick access to reference materials during and after customer demos.
-</Aside>
+- [WAF](https://f5xc-salesdemos.github.io/waf/)
+- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
+- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
+- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
+- [DDoS](https://f5xc-salesdemos.github.io/ddos/)


### PR DESCRIPTION
## Summary

- Rewrite all 6 demo guide pages to use a direct technical walkthrough tone
- Remove all "Talking Point" and "Key Message" asides, marketing language, and coaching instructions
- Remove value proposition content (threat landscape, Magecart history, PCI pitch, capability lists)
- Strip overview to demo flow and environment summary only
- Net reduction: 348 lines removed, 112 added

## Test plan

- [ ] GitHub Pages Deploy workflow succeeds
- [ ] All pages render correctly
- [ ] Sidebar ordering unchanged (1-6)
- [ ] CI checks pass

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)