### PR TITLE
docs: add alert trigger section to demo detection page

### DIFF
--- a/docs/demo-detection.mdx
+++ b/docs/demo-detection.mdx
@@ -5,7 +5,78 @@ sidebar:
   label: Detection & Mitigation
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Code, Steps } from "@astrojs/starlight/components";
+
+export const triggerScript = `function addAndReadDynamicField() {
+    // Create a container element
+    const wrapper = document.createElement('div');
+    wrapper.style.marginBottom = '10px';
+
+    // Generate a unique ID with credit-card-related naming
+    const uniqueId = 'creditdcard-' + Date.now();
+
+    // Create the label
+    const label = document.createElement('label');
+    label.textContent = 'Dynamic Credit User Input: ';
+    label.setAttribute('for', uniqueId);
+    label.style.fontWeight = 'bold';
+    label.style.marginRight = '5px';
+
+    // Create the text field with a dummy value
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.id = uniqueId;
+    input.value = 'Dummy Data ' + Math.floor(Math.random() * 1000);
+    input.className = 'csd-dynamic-field';
+
+    // Append to the DOM
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    document.body.appendChild(wrapper);
+
+    // Read ALL dynamically created fields
+    const allFields = document.querySelectorAll('.csd-dynamic-field');
+    console.log('Currently tracking ' + allFields.length + ' dynamic field(s):');
+    allFields.forEach(function(field, index) {
+        console.log('- Field [' + index + '] ID: ' + field.id + ' | Value: ' + field.value);
+    });
+}`;
+
+## Trigger Detection
+
+CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, you cannot trigger CSD detection with curl commands — it requires real browser-side script activity. The following script simulates a formjacking attack pattern that CSD is designed to detect.
+
+### Run the Simulation Script
+
+<Steps>
+1. Open the demo application in Chrome
+2. Open DevTools (**F12** → **Console** tab)
+3. Paste the following script into the console and press **Enter**
+
+   <Code code={triggerScript} lang="js" title="Formjacking Simulation" />
+
+4. Call the function several times to generate repeated suspicious activity
+
+   ```js
+   addAndReadDynamicField();
+   addAndReadDynamicField();
+   addAndReadDynamicField();
+   ```
+
+5. Each call dynamically injects a credit-card-named input field into the DOM and reads all injected field values — this is the exact pattern used by formjacking malware to harvest payment data
+</Steps>
+
+### Verify on the Dashboard
+
+<Steps>
+1. Navigate to the **Client-Side Defense** dashboard in the XC Console
+2. Check for new script detections or alerts related to the demo site
+3. Review the flagged activity — CSD should identify the dynamic DOM manipulation and data harvesting behavior
+</Steps>
+
+<Aside type="tip">
+Detection may take a few minutes to appear on the dashboard. If alerts are not yet visible, continue with the dashboard walkthrough below and check back.
+</Aside>
 
 ## Dashboard
 


### PR DESCRIPTION
## Summary

- Add **Trigger Detection** section to `docs/demo-detection.mdx` with a formjacking simulation script that triggers CSD alerts during live demos
- Script injects credit-card-named input fields and reads their values — mimicking the exact DOM manipulation pattern CSD is designed to detect
- Includes step-by-step instructions for running the script in Chrome DevTools and verifying alerts on the CSD dashboard

Closes #88

## Test plan

- [ ] CI checks pass (super-linter, markdown lint, editorconfig)
- [ ] GitHub Pages deploy succeeds
- [ ] Page renders correctly with the `<Code>` component and code blocks
- [ ] JavaScript in the code block is syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)