### PR TITLE
docs: add DevTools screenshot placeholders

### DIFF
--- a/docs/demo-detection.mdx
+++ b/docs/demo-detection.mdx
@@ -50,7 +50,11 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
 
 <Steps>
 1. Open the demo application in Chrome
+
 2. Open DevTools (**F12** → **Console** tab)
+
+   {/* ![DevTools Console tab](/csd/images/devtools-console.png) */}
+
 3. Paste the following script into the console and press **Enter**
 
    <Code code={triggerScript} lang="js" title="Formjacking Simulation" />
@@ -64,6 +68,12 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
    ```
 
 5. Each call dynamically injects a credit-card-named input field into the DOM and reads all injected field values — this is the exact pattern used by formjacking malware to harvest payment data
+
+   {/* ![Console output showing tracked dynamic fields](/csd/images/devtools-console-output.png) */}
+
+6. The injected fields are also visible on the page itself
+
+   {/* ![Injected credit card fields on the demo page](/csd/images/devtools-injected-fields.png) */}
 </Steps>
 
 ### Verify on the Dashboard


### PR DESCRIPTION
## Summary

- Add three commented-out image placeholders to the Trigger Detection section of `docs/demo-detection.mdx`
- `devtools-console.png` — DevTools Console tab open on the demo app
- `devtools-console-output.png` — console output after running the formjacking simulation
- `devtools-injected-fields.png` — injected credit card fields visible on the page

Closes #90

## Test plan

- [ ] CI checks pass (super-linter, markdown lint, editorconfig)
- [ ] GitHub Pages deploy succeeds
- [ ] Commented-out images do not render (no broken image links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)