### PR TITLE
docs: add DevTools screenshot to demo-console page

### DIFF
--- a/docs/demo-console.mdx
+++ b/docs/demo-console.mdx
@@ -61,6 +61,8 @@ Both the CSD tile and the HTTP LB configuration produce the same result.
 6. Confirm a second script `<script src="/common.js?async&seed=...">` was dynamically loaded
 </Steps>
 
+![Injected scripts in DevTools Elements tab](/csd/images/csd-injected-scripts.png)
+
 Both `common.js` scripts are injected by the F5 XC load balancer — they are not part of the application source. See the [Application Walkthrough](/csd/demo-website/#inspect-loaded-scripts) for a detailed breakdown of each injected script.
 
 <Aside type="caution">


### PR DESCRIPTION
## Summary
- Add the existing `csd-injected-scripts.png` screenshot to the "Verify Script Injection" section of `demo-console.mdx`
- The image is already used in `demo-website.mdx` — reusing it provides visual consistency
- Closes #114

## Test plan
- [ ] Verify the image renders correctly on the demo-console page
- [ ] Confirm the image path `/csd/images/csd-injected-scripts.png` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)