### PR TITLE
docs: add link and screenshot to Verify Script Injection step 1

### DIFF
--- a/docs/xc-configuration.mdx
+++ b/docs/xc-configuration.mdx
@@ -53,7 +53,9 @@ Both the CSD tile and the HTTP LB configuration produce the same result.
 ## Verify Script Injection
 
 <Steps>
-1. Open the demo application in Chrome
+1. Open the [demo application](https://botdemo.sales-demo.f5demos.com) in Chrome
+
+   ![Juice Shop home page](/csd/images/demo-app-home.png)
 2. Press **F12** to open DevTools
 3. Go to the **Elements** tab
 4. Search for `common.js` in the HTML


### PR DESCRIPTION
## Summary

- Adds a hyperlink to the demo application URL (`https://botdemo.sales-demo.f5demos.com`) in the "Verify Script Injection" step 1
- Adds the existing `demo-app-home.png` screenshot below the step for visual reference
- Reuses assets already present in `demo-website.mdx`

Closes #118

## Test plan

- [ ] Local dev server: navigate to `/csd/xc-configuration/` and confirm the link and image render correctly
- [ ] Verify the hyperlink points to `https://botdemo.sales-demo.f5demos.com`
- [ ] Verify the Juice Shop screenshot appears below step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)