### PR TITLE
docs: fix overview page title and sidebar label

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -1,13 +1,11 @@
 ---
-title: Overview
+title: Client-Side Defense Capabilities
 sidebar:
   order: 1
-  label: CSD Capabilities
+  label: Overview
 ---
 
 import { Aside } from "@astrojs/starlight/components";
-
-## How CSD Works
 
 F5 Distributed Cloud Client-Side Defense (CSD) protects web applications from client-side attacks by monitoring JavaScript behavior directly in the browser. The F5 XC load balancer injects a telemetry script into every page served to the client. This script observes all JavaScript activity — which scripts load, which form fields they read, and which network connections they make. Telemetry data is sent to the F5 XC platform where machine learning models analyze script behavior, assign risk scores, and flag anomalies. Security teams review detections in the CSD console and take action by allowing or mitigating script domains.
 


### PR DESCRIPTION
## Summary

- Swap title to "Client-Side Defense Capabilities" and sidebar label to "Overview" for clearer navigation
- Remove redundant "How CSD Works" heading since the content immediately follows

Closes #124

## Test plan

- [ ] Verify sidebar shows "Overview" as the label
- [ ] Verify page heading shows "Client-Side Defense Capabilities"
- [ ] Confirm no redundant "How CSD Works" heading appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)