### PR TITLE
docs: fix xc-configuration steps to match screenshots

### DIFF
--- a/docs/xc-configuration.mdx
+++ b/docs/xc-configuration.mdx
@@ -13,8 +13,9 @@ CSD is already enabled on the demo application. This section shows the configura
 
 <Steps>
 1. Log in to the **F5 Distributed Cloud Console**
-2. Select **Client-Side Defense** under **Common Services**
-3. In the managed tenant **f5-sales-demo**, select namespace **bot-defense**
+2. Select the **Client-Side Defense** workspace
+3. Set the namespace to **bot-defense**
+4. Navigate to **Manage** &rarr; **Configuration**
 </Steps>
 
 ![CSD Configuration page showing domain list](/csd/images/csd-config.png)
@@ -35,27 +36,20 @@ The HTTP Load Balancer is where JavaScript injection is configured. This control
 
 <Steps>
 1. Navigate to **Multi-Cloud App Connect** &rarr; **HTTP Load Balancers**
-2. Click **Manage Configuration** on the load balancer serving the application
+2. Click the **&hellip;** (actions) menu on the load balancer serving the application and select **Manage Configuration**
 
    ![HTTP Load Balancers list with Manage Configuration action](/csd/images/csd-lb-config.png)
-3. Click **Edit Configuration** in the top-right corner
-4. Open the **Common Security Controls** section
-5. Set **Client-Side Defense** to **Enabled** and click **Configure**
+3. Scroll to the **Client-Side Defense** section in the left sidebar
+
+   The **Client-Side Defense** field is set to **Enable** and the **Client-Side Defense Policy** shows **Configured**.
 
    ![CSD toggle and settings within the HTTP Load Balancer configuration](/csd/images/csd-lb-csd-settings.png)
-6. Select the JavaScript insertion scope:
+4. Click **View Configuration** to open the CSD policy details
 
-   | Mode | Description |
-   | --- | --- |
-   | **All pages** | CSD script injected on every page |
-   | **All pages with exceptions** | Exclude specific URL paths |
-   | **Custom** | Inject only on specified paths |
+   The **JavaScript Insertion Settings** field shows the injection scope. The demo load balancer is set to **Insert JavaScript in All Pages**.
 
-   ![JavaScript injection scope options in the CSD sub-configuration](/csd/images/csd-lb-injection-scope.png)
-7. Save and apply the load balancer configuration
+   ![JavaScript injection scope in the CSD sub-configuration](/csd/images/csd-lb-injection-scope.png)
 </Steps>
-
-The demo load balancer is set to **All pages**.
 
 <Aside type="tip">
 The CSD Configuration page (above) registers a domain with the reporting engine. The HTTP Load Balancer controls script injection. Both must be configured for CSD to function end-to-end.


### PR DESCRIPTION
## Summary

- Fixed "Navigate to Client-Side Defense" steps: corrected "Common Services" to workspace selection, added **Manage** → **Configuration** navigation step to match `csd-config.png` breadcrumb
- Rewrote "HTTP Load Balancer Method" section to describe the View (read-only) mode shown in screenshots instead of edit actions that don't match
- Fixed sidebar reference: CSD has its own dedicated section, not under "Common Security Controls"
- Replaced unverifiable injection scope mode table with actual UI label from screenshot

Closes #128

## Test plan

- [ ] Local docs preview renders without MDX errors
- [ ] Each step's bolded labels match the corresponding screenshot
- [ ] No step references UI elements not visible in its screenshot
- [ ] CI super-linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)