### PR TITLE
docs: remove duplication and unscreenshotted steps from demo-website

### DIFF
--- a/docs/demo-website.mdx
+++ b/docs/demo-website.mdx
@@ -15,36 +15,21 @@ Navigate to `https://botdemo.sales-demo.f5demos.com`. This is a Juice Shop e-com
 
 ## Review Pages with Form Inputs
 
-Browse pages that collect sensitive data:
+The login page is the primary page used in this demo:
 
 <Steps>
-1. **Login page** (`/#/login`) — email and password fields
+1. Navigate to the **Login page** (`/#/login`)
 
    ![Login form](/csd/images/demo-app-login.png)
 
-   The login page is the primary target for the CSD simulation in the [Detection &amp; Mitigation](/csd/demo-detection/) section. CSD auto-classifies the email and password fields as sensitive, making this page ideal for demonstrating formjacking detection.
-
-2. **Registration page** — email, password, security question
-3. **Payment / checkout** — credit card number, CVV, billing address
-4. **Customer feedback** — personal information and free-text fields
+   CSD auto-classifies the email and password fields as sensitive, making this page ideal for demonstrating formjacking detection. The [Detection &amp; Mitigation](/csd/demo-detection/) section uses this page.
 </Steps>
 
-These are the pages CSD monitors for unauthorized script activity.
+The application also has registration, payment, and feedback pages with form inputs. CSD monitors all pages where JavaScript injection is enabled.
 
-## Inspect Loaded Scripts
+## Injected CSD Scripts
 
-Open Chrome DevTools (**F12**) and go to the **Elements** tab. Search for `common.js` to locate the F5 XC injected scripts in the `<head>`:
-
-![Injected scripts in DevTools Elements tab](/csd/images/csd-injected-scripts.png)
-
-The F5 XC load balancer injects the CSD telemetry scripts into every page:
-
-| Script | Purpose |
-| --- | --- |
-| `/common.js?single` | Synchronous telemetry loader — initializes CSD monitoring |
-| `/common.js?async&seed=...` | Async telemetry payload — dynamically injected by the sync loader |
-
-These scripts monitor all JavaScript activity on the page and report back to the F5 XC platform. The third-party scripts on the page (jQuery, cookieconsent) and the application scripts (runtime, vendor, main) are all visible to CSD.
+The F5 XC load balancer injects two `common.js` telemetry scripts into every page served through the load balancer. To verify the scripts are present, see [Verify Script Injection](/csd/xc-configuration/#verify-script-injection).
 
 ## How CSD Telemetry Beacons Work
 


### PR DESCRIPTION
## Summary

- Trimmed "Review Pages with Form Inputs" to only the login page (the only page with a screenshot), with a note that other pages also have form inputs
- Replaced "Inspect Loaded Scripts" section with a cross-reference to the canonical "Verify Script Injection" section on xc-configuration — keeping content DRY since the reader encounters that page first (order 2 vs order 3)
- Kept the unique "How CSD Telemetry Beacons Work" section intact

Closes #130

## Test plan

- [ ] Local docs preview renders both pages without MDX errors
- [ ] Cross-reference link `/csd/xc-configuration/#verify-script-injection` resolves correctly
- [ ] No referenced images are missing from `docs/images/`
- [ ] Super-linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)