### PR TITLE
docs: document Juice Shop CSD attack surface on demo-website

### DIFF
--- a/docs/demo-website.mdx
+++ b/docs/demo-website.mdx
@@ -25,7 +25,19 @@ The login page is the primary page used in this demo:
    CSD auto-classifies the email and password fields as sensitive, making this page ideal for demonstrating formjacking detection. The [Detection &amp; Mitigation](/csd/demo-detection/) section uses this page.
 </Steps>
 
-The application also has registration, payment, and feedback pages with form inputs. CSD monitors all pages where JavaScript injection is enabled.
+The application has additional pages with form inputs that CSD monitors. Each page below collects data that a formjacking script could exfiltrate:
+
+| Page | Route | Sensitive Fields | Data Category |
+| --- | --- | --- | --- |
+| Registration | [`/#/register`](https://botdemo.sales-demo.f5demos.com/#/register) | email, password, security question &amp; answer | Credentials, account recovery |
+| Forgot Password | [`/#/forgot-password`](https://botdemo.sales-demo.f5demos.com/#/forgot-password) | email, security answer, new password | Credentials |
+| Payment | [`/#/payment/shop`](https://botdemo.sales-demo.f5demos.com/#/payment/shop) | cardholder name, card number, expiry | Financial |
+| Address | [`/#/address/create`](https://botdemo.sales-demo.f5demos.com/#/address/create) | name, mobile number, address, city, zip, country | PII |
+| Contact | [`/#/contact`](https://botdemo.sales-demo.f5demos.com/#/contact) | author, comment | PII |
+| Complaint | [`/#/complain`](https://botdemo.sales-demo.f5demos.com/#/complain) | email, message, file upload | PII |
+| Change Password | [`/#/privacy-security/change-password`](https://botdemo.sales-demo.f5demos.com/#/privacy-security/change-password) | current password, new password | Credentials |
+
+CSD monitors all pages where JavaScript injection is enabled — not just those listed above.
 
 ## Injected CSD Scripts
 


### PR DESCRIPTION
## Summary

- Replace vague sentence about form pages with a detailed table listing each Juice Shop page, its route, sensitive form fields, and data category
- Routes are clickable links to the demo domain (`botdemo.sales-demo.f5demos.com`)
- Covers Registration, Forgot Password, Payment, Address, Contact, Complaint, and Change Password pages

Closes #132

## Test plan

- [ ] CI passes (super-linter, markdown lint, codespell)
- [ ] Table renders correctly in docs site preview
- [ ] Route links resolve to correct Juice Shop pages
- [ ] No bare `&` in MDX (`&amp;` used instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)