### PR TITLE
docs: extract telemetry beacons into dedicated page

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 sidebar:
-  order: 6
+  order: 7
   label: API Reference
 ---
 

--- a/docs/attack-scripts.mdx
+++ b/docs/attack-scripts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attack Script Library
 sidebar:
-  order: 5
+  order: 6
   label: Attack Script Library
 ---
 

--- a/docs/demo-website.mdx
+++ b/docs/demo-website.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Demo Application
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Steps } from "@astrojs/starlight/components";
 
 ## Open the Demo Application
 
@@ -38,44 +38,3 @@ The application has additional pages with form inputs that CSD monitors. Each pa
 | Change Password | [`/#/privacy-security/change-password`](https://botdemo.sales-demo.f5demos.com/#/privacy-security/change-password) | current password, new password | Credentials |
 
 CSD monitors all pages where JavaScript injection is enabled — not just those listed above.
-
-## Injected CSD Scripts
-
-The F5 XC load balancer injects two `common.js` telemetry scripts into every page served through the load balancer. To verify the scripts are present, see [Verify Script Injection](/csd/xc-configuration/#verify-script-injection).
-
-## How CSD Telemetry Beacons Work
-
-After the `common.js` scripts initialize, they periodically send telemetry back to F5 XC via network requests known as **beacons**. These beacons are POST requests sent to `/common.js`-prefixed endpoints on the same load-balancer origin — the same domain that served the page. Because they are same-origin requests, they do not trigger CORS preflight checks and blend into normal application traffic.
-
-| Property | Value |
-| --- | --- |
-| Endpoint pattern | `POST /common.js?<parameters>` on the load-balancer origin |
-| HTTP method | POST |
-| Payload format | Encoded binary — not human-readable JSON |
-| Frequency | Periodic during page lifetime; additional beacons fire on specific events (form field access, new script load) |
-
-### What beacons report
-
-CSD beacons carry **script behavior metadata**, not user input:
-
-- **Script inventory** — which scripts loaded on the page and from which source domains
-- **Form field access events** — which scripts read or interacted with which input fields (field names and types)
-- **Page metadata** — current URL, timestamps, page lifecycle events
-
-Beacons do **not** send the values users type into form fields. Field names and input types are reported so the platform can detect unauthorized access patterns, but the actual data (passwords, card numbers, personal information) stays in the browser.
-
-### Observe beacons in DevTools
-
-<Steps>
-1. Open Chrome DevTools (**F12**) and switch to the **Network** tab
-2. In the filter bar, type `common.js` to isolate CSD traffic
-3. Set the method filter to **POST** (or look at the Method column) to distinguish beacons from the initial script loads (which are GET requests)
-4. Browse the application or interact with form fields — new POST entries appear as beacons fire
-5. Click a beacon request to inspect its headers and payload; note that the request body is encoded and not human-readable
-</Steps>
-
-<Aside type="tip" title="CSD beacons vs attack exfiltration">
-CSD telemetry beacons are **same-origin** POST requests to `/common.js` endpoints on the F5 XC load balancer. A malicious formjacking script, by contrast, exfiltrates stolen data **cross-origin** — typically via `fetch()`, `XMLHttpRequest`, or image beacon (`new Image().src`) to an attacker-controlled domain.
-
-The key difference: CSD beacons report **metadata about script behavior** to F5 XC, while exfiltration sends **user-entered data** to an external server. This distinction is central to how CSD detects attacks — see [CSD Capabilities — Detection Boundaries](/csd/capabilities/#detection-boundaries) for what CSD can and cannot observe.
-</Aside>

--- a/docs/detection-mitigation.mdx
+++ b/docs/detection-mitigation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Detection & Mitigation
 sidebar:
-  order: 4
+  order: 5
   label: Detection & Mitigation
 ---
 

--- a/docs/references.mdx
+++ b/docs/references.mdx
@@ -1,7 +1,7 @@
 ---
 title: References
 sidebar:
-  order: 7
+  order: 8
 ---
 
 ## Documentation

--- a/docs/telemetry-beacons.mdx
+++ b/docs/telemetry-beacons.mdx
@@ -1,0 +1,43 @@
+---
+title: Telemetry Beacons
+sidebar:
+  order: 4
+  label: Telemetry Beacons
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+After the `common.js` scripts initialize, they periodically send telemetry back to F5 XC via network requests known as **beacons**. These beacons are POST requests sent to `/common.js`-prefixed endpoints on the same load-balancer origin — the same domain that served the page. Because they are same-origin requests, they do not trigger CORS preflight checks and blend into normal application traffic.
+
+| Property | Value |
+| --- | --- |
+| Endpoint pattern | `POST /common.js?<parameters>` on the load-balancer origin |
+| HTTP method | POST |
+| Payload format | Encoded binary — not human-readable JSON |
+| Frequency | Periodic during page lifetime; additional beacons fire on specific events (form field access, new script load) |
+
+## What beacons report
+
+CSD beacons carry **script behavior metadata**, not user input:
+
+- **Script inventory** — which scripts loaded on the page and from which source domains
+- **Form field access events** — which scripts read or interacted with which input fields (field names and types)
+- **Page metadata** — current URL, timestamps, page lifecycle events
+
+Beacons do **not** send the values users type into form fields. Field names and input types are reported so the platform can detect unauthorized access patterns, but the actual data (passwords, card numbers, personal information) stays in the browser.
+
+## Observe beacons in DevTools
+
+<Steps>
+1. Open Chrome DevTools (**F12**) and switch to the **Network** tab
+2. In the filter bar, type `common.js` to isolate CSD traffic
+3. Set the method filter to **POST** (or look at the Method column) to distinguish beacons from the initial script loads (which are GET requests)
+4. Browse the application or interact with form fields — new POST entries appear as beacons fire
+5. Click a beacon request to inspect its headers and payload; note that the request body is encoded and not human-readable
+</Steps>
+
+<Aside type="tip" title="CSD beacons vs attack exfiltration">
+CSD telemetry beacons are **same-origin** POST requests to `/common.js` endpoints on the F5 XC load balancer. A malicious formjacking script, by contrast, exfiltrates stolen data **cross-origin** — typically via `fetch()`, `XMLHttpRequest`, or image beacon (`new Image().src`) to an attacker-controlled domain.
+
+The key difference: CSD beacons report **metadata about script behavior** to F5 XC, while exfiltration sends **user-entered data** to an external server. This distinction is central to how CSD detects attacks — see [CSD Capabilities — Detection Boundaries](/csd/capabilities/#detection-boundaries) for what CSD can and cannot observe.
+</Aside>


### PR DESCRIPTION
## Summary

- Remove duplicated "Injected CSD Scripts" section from `demo-website.mdx` (already covered in `xc-configuration.mdx` under "Verify Script Injection")
- Extract "How CSD Telemetry Beacons Work" content into new `telemetry-beacons.mdx` page (sidebar order 4)
- Bump sidebar order for downstream pages: detection-mitigation (5), attack-scripts (6), api-reference (7), references (8)

## Test plan

- [ ] CI passes (super-linter: markdown, editorconfig, codespell, etc.)
- [ ] Sidebar shows: ... Demo Application → Telemetry Beacons → Detection & Mitigation → ...
- [ ] No broken internal links
- [ ] Content in telemetry-beacons.mdx matches original content from demo-website.mdx

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)