### PR TITLE
fix: add Affected Clients column to Script List table

### DIFF
--- a/docs/detection-mitigation.mdx
+++ b/docs/detection-mitigation.mdx
@@ -174,6 +174,7 @@ Open the **Script List** from the left navigation to view all detected scripts.
 | **Locations Found** | Number of pages where the script was observed |
 | **Network Interactions** | Count of network calls made by the script |
 | **Form Fields** | Number of form fields the script reads |
+| **Affected Clients** | Number of unique users/sessions affected by the script |
 
 After running the combined simulation, you should see:
 


### PR DESCRIPTION
## Summary
- Adds the missing **Affected Clients** column to the Script List table in `detection-mitigation.mdx`
- Column describes the number of unique users/sessions affected by the script, matching the actual CSD console UI

Closes #150

## Test plan
- [ ] CI passes (super-linter, markdown checks)
- [ ] Live GitHub Pages renders the table with 8 columns
- [ ] Column order matches the CSD console UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)