### PR TITLE
fix: update annotate-screenshot.cjs default width from 1490 to 1600

### DIFF
--- a/scripts/annotate-screenshot.cjs
+++ b/scripts/annotate-screenshot.cjs
@@ -12,7 +12,7 @@ if (!screenshotPath || !outputPath || !badgesJson) {
   process.exit(1);
 }
 
-const w = parseInt(width, 10) || 1490;
+const w = parseInt(width, 10) || 1600;
 const h = parseInt(height, 10) || 900;
 const badges = JSON.parse(badgesJson);
 


### PR DESCRIPTION
## Summary

- Updates the default fallback width in `scripts/annotate-screenshot.cjs` from `1490` to `1600` to match the 1600x900 screenshot standard established in PR #179

## Test plan

- [x] `grep 1490` across the entire repo returns no matches
- [ ] CI passes

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)