### PR TITLE
fix: replace cdnjs.cloudflare.com with esm.sh and add ga.jspm.io

### DIFF
--- a/docs/attack-scripts.mdx
+++ b/docs/attack-scripts.mdx
@@ -20,7 +20,7 @@ All scripts in this library follow these conventions:
 
 - **IIFE format** — self-executing, paste-and-run in DevTools Console
 - **Safe exfil targets** — `httpbin.org`, `jsonplaceholder.typicode.com`
-- **Safe script sources** — `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com` (loading benign libraries)
+- **Safe script sources** — `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, `ga.jspm.io` (loading benign libraries)
 - **`mode: 'no-cors'`** on all fetch calls
 - **`var` declarations** for console compatibility
 - **Console output** prefixed with `[CSD Demo]` and a category tag
@@ -208,7 +208,7 @@ export const obfuscatedLoader = `// CSD Demo — Multi-Stage Obfuscated Loader
 
 **Target page:** Any page on the demo site
 
-**CSD signals:** Script injection (3 new third-party script tags), network (3 new domains)
+**CSD signals:** Script injection (4 new third-party script tags), network (4 new domains)
 
 export const multiCdn = `// CSD Demo — Multi-CDN Script Injection
 (function() {
@@ -216,8 +216,9 @@ export const multiCdn = `// CSD Demo — Multi-CDN Script Injection
 
     var cdns = [
         { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
-        { url: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js', name: 'cdnjs' },
-        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' }
+        { url: 'https://esm.sh/moment@2.30.1', name: 'esm.sh' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' },
+        { url: 'https://ga.jspm.io/npm:axios@1.7.9/index.js', name: 'jspm' }
     ];
 
     cdns.forEach(function(cdn) {
@@ -233,14 +234,14 @@ export const multiCdn = `// CSD Demo — Multi-CDN Script Injection
         console.log('[CSD Demo][Supply Chain] Injected script tag: ' + cdn.name);
     });
 
-    console.log('[CSD Demo][Supply Chain] 3 third-party scripts injected. CSD will detect all 3 new domains.');
+    console.log('[CSD Demo][Supply Chain] 4 third-party scripts injected. CSD will detect all 4 new domains.');
 })();`;
 
 <Code code={multiCdn} lang="js" title="Multi-CDN Script Injection" />
 
 **Verify in CSD console:**
-- **Script List** — 3 new script entries from `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com`
-- **Network** — all 3 CDN domains appear in the All Domains list
+- **Script List** — 4 new script entries from `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, `ga.jspm.io`
+- **Network** — all 4 CDN domains appear in the All Domains list
 
 ### Tag Manager Hijack Simulation
 
@@ -364,10 +365,10 @@ export const highVolume = `// CSD Demo — High-Volume Domain Exfiltration
     // Inject scripts from multiple CDN domains (these WILL appear in CSD Network view)
     var sources = [
         'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js',
+        'https://esm.sh/moment@2.30.1',
         'https://unpkg.com/underscore@1.13.7/underscore-min.js',
         'https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js',
-        'https://cdnjs.cloudflare.com/ajax/libs/axios/1.7.9/axios.min.js'
+        'https://ga.jspm.io/npm:axios@1.7.9/index.js'
     ];
 
     sources.forEach(function(src, i) {
@@ -394,7 +395,7 @@ export const highVolume = `// CSD Demo — High-Volume Domain Exfiltration
 
 **Verify in CSD console:**
 - **Script List** — 5 new third-party script entries
-- **Network** — `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com` domains listed
+- **Network** — `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, `ga.jspm.io` domains listed
 - **Form Fields** — login fields show read activity
 
 ---
@@ -523,7 +524,7 @@ This script combines all attack vectors into a single IIFE — the "ultimate dem
 
 **Target page:** `/#/login` — enter dummy credentials before running
 
-**CSD signals:** Form field reads, script injection (3 CDN domains), network (3 new domains)
+**CSD signals:** Form field reads, script injection (4 CDN domains), network (4 new domains)
 
 export const maxDetection = `// CSD Demo — Maximum Detection (Combined Stress Test)
 (function() {
@@ -545,8 +546,9 @@ export const maxDetection = `// CSD Demo — Maximum Detection (Combined Stress 
     console.log('\\n--- Phase 2: Supply Chain — Multi-CDN Injection ---');
     var cdns = [
         { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr (lodash)' },
-        { url: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js', name: 'cdnjs (moment)' },
-        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg (underscore)' }
+        { url: 'https://esm.sh/moment@2.30.1', name: 'esm.sh (moment)' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg (underscore)' },
+        { url: 'https://ga.jspm.io/npm:axios@1.7.9/index.js', name: 'jspm (axios)' }
     ];
     cdns.forEach(function(cdn) {
         var script = document.createElement('script');
@@ -621,7 +623,7 @@ export const maxDetection = `// CSD Demo — Maximum Detection (Combined Stress 
 
 **Verify in CSD console (after 5-10 minutes):**
 - **Dashboard** — Transactions Consumed counter increments
-- **Script List** — application scripts flagged High Risk; 3 new third-party scripts from CDN domains
+- **Script List** — application scripts flagged High Risk; 4 new third-party scripts from CDN domains
 - **Form Fields** — email and password classified as Sensitive (by system) with read activity
-- **Network** — `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, `unpkg.com` appear in All Domains
+- **Network** — `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, `ga.jspm.io` appear in All Domains
 - **Affected Users** — your session appears with IP, geolocation, browser, device info

--- a/docs/detection-mitigation.mdx
+++ b/docs/detection-mitigation.mdx
@@ -25,12 +25,13 @@ export const combinedScript = `// CSD Demo — Combined Detection Script
     });
     console.log('[Formjack] Harvested ' + Object.keys(harvested).length + ' fields:', harvested);
 
-    // Phase 2: Inject third-party scripts from 3 CDN domains
+    // Phase 2: Inject third-party scripts from 4 CDN domains
     console.log('\\n[Supply Chain] Phase 2: Multi-CDN script injection');
     var cdns = [
         { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
-        { url: 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js', name: 'cdnjs' },
-        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' }
+        { url: 'https://esm.sh/moment@2.30.1', name: 'esm.sh' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' },
+        { url: 'https://ga.jspm.io/npm:axios@1.7.9/index.js', name: 'jspm' }
     ];
     cdns.forEach(function(cdn) {
         var script = document.createElement('script');
@@ -75,7 +76,7 @@ export const combinedScript = `// CSD Demo — Combined Detection Script
     console.log('\\n' + '='.repeat(50));
     console.log('[CSD Demo] Simulation complete');
     console.log('[CSD Demo] Fields harvested: ' + Object.keys(harvested).length);
-    console.log('[CSD Demo] Scripts injected: ' + cdns.length + ' (3 CDN domains)');
+    console.log('[CSD Demo] Scripts injected: ' + cdns.length + ' (4 CDN domains)');
     console.log('[CSD Demo] Exfil channels: 2 (fetch POST)');
     console.log('[CSD Demo] Detection takes 5-10 minutes to appear in the CSD console.');
     console.log('='.repeat(50));
@@ -100,7 +101,7 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
 
    <Code code={combinedScript} lang="js" title="Combined Detection Script" />
 
-5. Observe the phased `[CSD Demo]` console output confirming each step: field harvesting, script injection from 3 CDN domains, and data exfiltration
+5. Observe the phased `[CSD Demo]` console output confirming each step: field harvesting, script injection from 4 CDN domains, and data exfiltration
 
    <Screenshot light="/images/devtools-console-output-light.png" dark="/images/devtools-console-output-dark.png" alt="Console output after running the simulation script" />
 </Steps>
@@ -116,7 +117,7 @@ The combined simulation triggers all three CSD detection signals:
 | Behavior | What the Script Does | What CSD Sees |
 | --- | --- | --- |
 | **Field harvesting** | Reads values from existing `input` elements (email, password) | Scripts reading sensitive form fields — flagged High Risk |
-| **Script injection** | Appends 3 `<script>` tags loading from `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, and `unpkg.com` | 3 new third-party script domains on the page |
+| **Script injection** | Appends 4 `<script>` tags loading from `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, and `ga.jspm.io` | 4 new third-party script domains on the page |
 | **Data exfiltration** | Sends harvested data via `fetch` to `httpbin.org` and `jsonplaceholder.typicode.com` | Network calls to external domains (note: fetch destinations appear as script network interactions, not in the Network domain view) |
 
 <Aside type="note">
@@ -148,8 +149,9 @@ After running the combined simulation, the following domains should appear once 
 | Domain | Source |
 | --- | --- |
 | `cdn.jsdelivr.net` | Injected script (lodash) |
-| `cdnjs.cloudflare.com` | Injected script (moment.js) |
+| `esm.sh` | Injected script (moment) |
 | `unpkg.com` | Injected script (underscore) |
+| `ga.jspm.io` | Injected script (axios) |
 
 <Aside type="note">
 If no third-party scripts have been actioned yet, the domain table may show "No data found." This is expected — new detections appear in the **Script List** first, and only move to the dashboard domain table after being actioned (allowed or mitigated).
@@ -180,7 +182,7 @@ Open the **Script List** from the left navigation to view all detected scripts.
 After running the combined simulation, you should see:
 
 - **Application scripts** (e.g., `main.js`, `vendor.js`) flagged as **High Risk / Action Needed** because they read sensitive form fields (email, password)
-- **3 new third-party scripts** from `cdn.jsdelivr.net`, `cdnjs.cloudflare.com`, and `unpkg.com` appearing as new entries in the list
+- **4 new third-party scripts** from `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, and `ga.jspm.io` appearing as new entries in the list
 
 <Steps>
 1. Sort by **Risk Level** (High Risk first)
@@ -232,8 +234,9 @@ After running the combined simulation, these domains should appear as new entrie
 | Domain | Library Loaded |
 | --- | --- |
 | `cdn.jsdelivr.net` | lodash |
-| `cdnjs.cloudflare.com` | moment.js |
+| `esm.sh` | moment |
 | `unpkg.com` | underscore |
+| `ga.jspm.io` | axios |
 
 Use the **Mitigate List** and **Allow List** tabs to review domains that have already been actioned.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -25,7 +25,7 @@ CSD monitors three categories of browser-side behavior:
 | --- | --- | --- |
 | **Form field reads** | Which scripts access which `input` fields present in the page DOM at load time | `main.js` reading the `password` field on `/login` |
 | **Script inventory** | All first-party and third-party JavaScript loaded on each page, tracked by source domain | A new `<script>` tag loading from `cdn.jsdelivr.net` appearing on the login page |
-| **Network interactions** | Domains that scripts load resources from (script source domains) | Scripts sourced from `cdnjs.cloudflare.com` appearing in the Network view |
+| **Network interactions** | Domains that scripts load resources from (script source domains) | Scripts sourced from `esm.sh` appearing in the Network view |
 
 <Aside type="caution">
 CSD tracks **script-load source domains** in the Network view — not fetch/XHR destination domains. If a script sends data via `fetch()` to `evil.com`, that domain does not appear in the Network view. See [Detection Boundaries](#detection-boundaries) for the full list of limitations.


### PR DESCRIPTION
## Summary

- Replace `cdnjs.cloudflare.com` (moment.js) with `esm.sh` (moment) to remove competitor branding from demo output
- Add `ga.jspm.io` (axios) as a 4th CDN domain to increase CSD detection signal surface
- Update all script arrays, prose counts, domain tables, and verify text across `detection-mitigation.mdx`, `attack-scripts.mdx`, and `overview.mdx`

Closes #190

## Test plan

- [ ] Verify `grep -ri cloudflare docs/` returns zero results
- [ ] Verify `grep -n "3 CDN\|3 new.*script\|3 third" docs/` returns zero results
- [ ] Confirm `curl -sI https://esm.sh/moment@2.30.1` returns HTTP 200
- [ ] Confirm `curl -sI https://ga.jspm.io/npm:axios@1.7.9/index.js` returns HTTP 200
- [ ] CI passes (super-linter, markdown, biome, jscpd, codespell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)