### PR TITLE
docs: add Console panel and helper scripts sections to SCREENSHOT-INSTRUCTIONS.md

### DIFF
--- a/SCREENSHOT-INSTRUCTIONS.md
+++ b/SCREENSHOT-INSTRUCTIONS.md
@@ -1957,7 +1957,9 @@ When you need to capture a screenshot showing script execution output in the Dev
 
 ### Why `prompt.appendCommand()` instead of `Runtime.evaluate`
 
-`Runtime.evaluate` on the page target from an external CDP session does **not** produce visible `console.log` output in the DevTools Console panel. The output goes to the CDP session's response, not the DevTools UI. Using `prompt.appendCommand()` on the DevTools target routes the evaluation through the Console panel's own pipeline, so `console.log` output appears exactly as if the user pasted and ran the script.
+`Runtime.evaluate` on the page target from an external CDP session does **not** produce visible `console.log` output in the DevTools Console panel.
+The output goes to the CDP session's response, not the DevTools UI.
+Using `prompt.appendCommand()` on the DevTools target routes the evaluation through the Console panel's own pipeline, so `console.log` output appears exactly as if the user pasted and ran the script.
 
 ### DevTools Console API surface
 


### PR DESCRIPTION
## Summary

- Add **Section 16: Console Panel Screenshots** documenting the workflow for capturing Console panel output, including the DevTools Console API surface (`prompt.appendCommand`, `clearConsole`, `immediatelyScrollToBottom`) and why `prompt.appendCommand()` is needed instead of `Runtime.evaluate` for visible console output
- Add **Section 17: Committed Helper Scripts Reference** cataloguing all 5 scripts in `scripts/` with usage, parameters, prerequisites, and cross-references
- Add cross-reference links in existing Sections 4, 14, and 15 pointing to the new sections

## Test plan

- [ ] Verify all 5 script filenames appear in the updated doc
- [ ] Verify section numbers (14-17) are sequential with no gaps or renumbering
- [ ] CI passes (super-linter, markdownlint, editorconfig)
- [ ] Read through new sections to confirm they match actual script implementations

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)