### PR TITLE
docs: add Diagnostics & Monitoring page

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: API Reference
 sidebar:
-  order: 9
+  order: 10
   label: API Reference
 ---
 
@@ -13,90 +13,89 @@ CSD has a dedicated API at `/api/shape/csd/` for managing domains, scripts, miti
 
 All API calls require an API token. Generate one in the XC Console under **Administration** &rarr; **Credentials** &rarr; **API Credentials**.
 
+Set up your environment variables as described in [API Automation &mdash; Environment Setup](/csd/api-automation/#environment-setup):
+
 ```bash
-export F5XC_TENANT="your-tenant"
-export F5XC_API_URL="https://${F5XC_TENANT}.console.ves.volterra.io"
-export F5XC_API_TOKEN="your-api-token"
-export F5XC_NAMESPACE="your-namespace"
+set -a && source .env && set +a
 ```
 
-All curl examples use:
+All curl examples use the `xTOKENx` placeholder format. Substitute with your environment variables or use the interactive form at the top of the page. For example, `xF5XC_API_TOKENx` corresponds to `$F5XC_API_TOKEN`.
 
 ```bash
--H "Authorization: APIToken ${F5XC_API_TOKEN}"
+-H "Authorization: APIToken xF5XC_API_TOKENx"
 ```
 
 ## CSD API Endpoints
 
-Base path: `/api/shape/csd/namespaces/{namespace}/`
+Base path: `/api/shape/csd/namespaces/\{namespace\}/`
 
 ### Status and Initialization
 
 | Operation | Method | Path |
 | --- | --- | --- |
 | Enable CSD | `POST` | `/api/shape/csd/namespaces/system/init` |
-| Get Status | `GET` | `/api/shape/csd/namespaces/{namespace}/status` |
-| Get JS Configuration | `GET` | `/api/shape/csd/namespaces/{namespace}/js_configuration` |
-| Test JS | `POST` | `/api/shape/csd/namespaces/{namespace}/testjs` |
-| Update Domains | `POST` | `/api/shape/csd/namespaces/{namespace}/update_domains` |
+| Get Status | `GET` | `/api/shape/csd/namespaces/\{namespace\}/status` |
+| Get JS Configuration | `GET` | `/api/shape/csd/namespaces/\{namespace\}/js_configuration` |
+| Test JS | `POST` | `/api/shape/csd/namespaces/\{namespace\}/testjs` |
+| Update Domains | `POST` | `/api/shape/csd/namespaces/\{namespace\}/update_domains` |
 
 ### Protected Domains
 
 | Operation | Method | Path |
 | --- | --- | --- |
-| List | `GET` | `/api/shape/csd/namespaces/{namespace}/protected_domains` |
-| Get | `GET` | `/api/shape/csd/namespaces/{namespace}/protected_domains/{name}` |
-| Create | `POST` | `/api/shape/csd/namespaces/{namespace}/protected_domains` |
-| Delete | `DELETE` | `/api/shape/csd/namespaces/{namespace}/protected_domains/{name}` |
+| List | `GET` | `/api/shape/csd/namespaces/\{namespace\}/protected_domains` |
+| Get | `GET` | `/api/shape/csd/namespaces/\{namespace\}/protected_domains/\{name\}` |
+| Create | `POST` | `/api/shape/csd/namespaces/\{namespace\}/protected_domains` |
+| Delete | `DELETE` | `/api/shape/csd/namespaces/\{namespace\}/protected_domains/\{name\}` |
 
 ### Detected Domains
 
 | Operation | Method | Path |
 | --- | --- | --- |
-| List Detected | `GET` | `/api/shape/csd/namespaces/{namespace}/detected_domains` |
-| Get Details | `GET` | `/api/shape/csd/namespaces/{namespace}/domain_details` |
+| List Detected | `GET` | `/api/shape/csd/namespaces/\{namespace\}/detected_domains` |
+| Get Details | `GET` | `/api/shape/csd/namespaces/\{namespace\}/domain_details` |
 
 ### Allowed Domains
 
 | Operation | Method | Path |
 | --- | --- | --- |
-| List | `GET` | `/api/shape/csd/namespaces/{namespace}/allowed_domains` |
-| Get | `GET` | `/api/shape/csd/namespaces/{namespace}/allowed_domains/{name}` |
-| Create | `POST` | `/api/shape/csd/namespaces/{namespace}/allowed_domains` |
-| Delete | `DELETE` | `/api/shape/csd/namespaces/{namespace}/allowed_domains/{name}` |
+| List | `GET` | `/api/shape/csd/namespaces/\{namespace\}/allowed_domains` |
+| Get | `GET` | `/api/shape/csd/namespaces/\{namespace\}/allowed_domains/\{name\}` |
+| Create | `POST` | `/api/shape/csd/namespaces/\{namespace\}/allowed_domains` |
+| Delete | `DELETE` | `/api/shape/csd/namespaces/\{namespace\}/allowed_domains/\{name\}` |
 
 ### Mitigated Domains
 
 | Operation | Method | Path |
 | --- | --- | --- |
-| List | `GET` | `/api/shape/csd/namespaces/{namespace}/mitigated_domains` |
-| Get | `GET` | `/api/shape/csd/namespaces/{namespace}/mitigated_domains/{name}` |
-| Create | `POST` | `/api/shape/csd/namespaces/{namespace}/mitigated_domains` |
-| Delete | `DELETE` | `/api/shape/csd/namespaces/{namespace}/mitigated_domains/{name}` |
+| List | `GET` | `/api/shape/csd/namespaces/\{namespace\}/mitigated_domains` |
+| Get | `GET` | `/api/shape/csd/namespaces/\{namespace\}/mitigated_domains/\{name\}` |
+| Create | `POST` | `/api/shape/csd/namespaces/\{namespace\}/mitigated_domains` |
+| Delete | `DELETE` | `/api/shape/csd/namespaces/\{namespace\}/mitigated_domains/\{name\}` |
 
 ### Scripts
 
 | Operation | Method | Path |
 | --- | --- | --- |
-| List Scripts | `POST` | `/api/shape/csd/namespaces/{namespace}/scripts` |
-| List Scripts (legacy) | `GET` | `/api/shape/csd/namespaces/{namespace}/scripts` |
-| Get Script Overview | `GET` | `/api/shape/csd/namespaces/{namespace}/scripts/{id}/dashboard` |
-| List Behaviors | `GET` | `/api/shape/csd/namespaces/{namespace}/scripts/{id}/behaviors` |
-| List Network Interactions | `GET` | `/api/shape/csd/namespaces/{namespace}/scripts/{id}/networkInteractions` |
-| Update Justification | `POST` | `/api/shape/csd/namespaces/{namespace}/scripts/{script_id}/justification` |
-| Delete Justification | `DELETE` | `/api/shape/csd/namespaces/{namespace}/script/justification/{justification_id}` |
-| Update Read Status | `POST` | `/api/shape/csd/namespaces/{namespace}/scripts/{id}/readStatus` |
-| List Affected Users | `POST` | `/api/shape/csd/namespaces/{namespace}/scripts/{script_id}/affectedUsers` |
+| List Scripts | `POST` | `/api/shape/csd/namespaces/\{namespace\}/scripts` |
+| List Scripts (legacy) | `GET` | `/api/shape/csd/namespaces/\{namespace\}/scripts` |
+| Get Script Overview | `GET` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{id\}/dashboard` |
+| List Behaviors | `GET` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{id\}/behaviors` |
+| List Network Interactions | `GET` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{id\}/networkInteractions` |
+| Update Justification | `POST` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{script_id\}/justification` |
+| Delete Justification | `DELETE` | `/api/shape/csd/namespaces/\{namespace\}/script/justification/\{justification_id\}` |
+| Update Read Status | `POST` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{id\}/readStatus` |
+| List Affected Users | `POST` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{script_id\}/affectedUsers` |
 
 ### Form Fields
 
 | Operation | Method | Path |
 | --- | --- | --- |
-| List Form Fields | `GET` | `/api/shape/csd/namespaces/{namespace}/formFields` |
-| List Form Fields (POST) | `POST` | `/api/shape/csd/namespaces/{namespace}/formFields` |
-| Get Form Field | `GET` | `/api/shape/csd/namespaces/{namespace}/formFields/{id}` |
-| List by Script | `GET` | `/api/shape/csd/namespaces/{namespace}/scripts/{id}/formFields` |
-| Update Field Analysis | `POST` | `/api/shape/csd/namespaces/{namespace}/formFields/analysis` |
+| List Form Fields | `GET` | `/api/shape/csd/namespaces/\{namespace\}/formFields` |
+| List Form Fields (POST) | `POST` | `/api/shape/csd/namespaces/\{namespace\}/formFields` |
+| Get Form Field | `GET` | `/api/shape/csd/namespaces/\{namespace\}/formFields/\{id\}` |
+| List by Script | `GET` | `/api/shape/csd/namespaces/\{namespace\}/scripts/\{id\}/formFields` |
+| Update Field Analysis | `POST` | `/api/shape/csd/namespaces/\{namespace\}/formFields/analysis` |
 
 ## Enable CSD
 
@@ -104,17 +103,17 @@ Initialize CSD for the tenant:
 
 ```bash
 curl -s -X POST \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
   -H "Content-Type: application/json" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/system/init"
+  "xF5XC_API_URLx/api/shape/csd/namespaces/system/init"
 ```
 
 ## Get CSD Status
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/status" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/status" \
   | jq .
 ```
 
@@ -124,8 +123,8 @@ curl -s \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/protected_domains" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains" \
   | jq .
 ```
 
@@ -133,16 +132,16 @@ curl -s \
 
 ```bash
 curl -s -X POST \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
   -H "Content-Type: application/json" \
   -d '{
     "metadata": {
       "name": "my-app",
-      "namespace": "'"${F5XC_NAMESPACE}"'"
+      "namespace": "xF5XC_NAMESPACEx"
     },
     "spec": {}
   }' \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/protected_domains" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains" \
   | jq .
 ```
 
@@ -150,8 +149,8 @@ curl -s -X POST \
 
 ```bash
 curl -s -X DELETE \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/protected_domains/my-app"
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains/my-app"
 ```
 
 ## Detected Domains
@@ -162,8 +161,8 @@ Query parameters: `locations` (filter by location), `risk` (filter by risk level
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/detected_domains" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/detected_domains" \
   | jq .
 ```
 
@@ -171,8 +170,8 @@ Filter by high risk:
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/detected_domains?risk=high" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/detected_domains?risk=high" \
   | jq .
 ```
 
@@ -180,8 +179,8 @@ curl -s \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/domain_details?name=suspicious.example.com" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/domain_details?name=suspicious.example.com" \
   | jq .
 ```
 
@@ -191,10 +190,10 @@ curl -s \
 
 ```bash
 curl -s -X POST \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
   -H "Content-Type: application/json" \
   -d '{}' \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/scripts" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts" \
   | jq .
 ```
 
@@ -204,8 +203,8 @@ curl -s -X POST \
 SCRIPT_ID="your-script-id"
 
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/scripts/${SCRIPT_ID}/dashboard" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/dashboard" \
   | jq .
 ```
 
@@ -213,8 +212,8 @@ curl -s \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/scripts/${SCRIPT_ID}/behaviors" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/behaviors" \
   | jq .
 ```
 
@@ -222,8 +221,8 @@ curl -s \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/scripts/${SCRIPT_ID}/networkInteractions" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/networkInteractions" \
   | jq .
 ```
 
@@ -233,16 +232,16 @@ curl -s \
 
 ```bash
 curl -s -X POST \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
   -H "Content-Type: application/json" \
   -d '{
     "metadata": {
       "name": "blocked-domain",
-      "namespace": "'"${F5XC_NAMESPACE}"'"
+      "namespace": "xF5XC_NAMESPACEx"
     },
     "spec": {}
   }' \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/mitigated_domains" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/mitigated_domains" \
   | jq .
 ```
 
@@ -250,8 +249,8 @@ curl -s -X POST \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/mitigated_domains" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/mitigated_domains" \
   | jq .
 ```
 
@@ -259,8 +258,8 @@ curl -s \
 
 ```bash
 curl -s -X DELETE \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/mitigated_domains/blocked-domain"
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/mitigated_domains/blocked-domain"
 ```
 
 ## Allowed Domains
@@ -269,16 +268,16 @@ curl -s -X DELETE \
 
 ```bash
 curl -s -X POST \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
   -H "Content-Type: application/json" \
   -d '{
     "metadata": {
       "name": "trusted-cdn",
-      "namespace": "'"${F5XC_NAMESPACE}"'"
+      "namespace": "xF5XC_NAMESPACEx"
     },
     "spec": {}
   }' \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/allowed_domains" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/allowed_domains" \
   | jq .
 ```
 
@@ -286,8 +285,8 @@ curl -s -X POST \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/allowed_domains" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/allowed_domains" \
   | jq .
 ```
 
@@ -295,8 +294,8 @@ curl -s \
 
 ```bash
 curl -s -X DELETE \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/allowed_domains/trusted-cdn"
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/allowed_domains/trusted-cdn"
 ```
 
 ## JS Injection Configuration
@@ -305,14 +304,14 @@ curl -s -X DELETE \
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/shape/csd/namespaces/${F5XC_NAMESPACE}/js_configuration" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/js_configuration" \
   | jq .
 ```
 
 ## HTTP Load Balancer CSD Configuration
 
-CSD JavaScript injection can also be enabled directly on an HTTP Load Balancer via the configuration API at `/api/config/namespaces/{namespace}/http_loadbalancers/{name}`.
+CSD JavaScript injection can also be enabled directly on an HTTP Load Balancer via the configuration API at `/api/config/namespaces/\{namespace\}/http_loadbalancers/\{name\}`.
 
 The `client_side_defense` field within the load balancer spec controls injection:
 
@@ -335,16 +334,14 @@ The `policy` accepts one of:
 | `js_insertion_rules` | Inject only on pages matching rules |
 | `disable_js_insert` | Do not inject |
 
-To disable CSD on a load balancer, replace `client_side_defense` with `disable_client_side_defense: {}`.
+To disable CSD on a load balancer, replace `client_side_defense` with `disable_client_side_defense: \{\}`.
 
 ### Read CSD Configuration from Load Balancer
 
 ```bash
-export F5XC_LB_NAME="your-http-loadbalancer"
-
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/config/namespaces/${F5XC_NAMESPACE}/http_loadbalancers/${F5XC_LB_NAME}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx" \
   | jq '.spec.client_side_defense'
 ```
 
@@ -354,8 +351,8 @@ Retrieve, modify, and apply:
 
 ```bash
 curl -s \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/config/namespaces/${F5XC_NAMESPACE}/http_loadbalancers/${F5XC_LB_NAME}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx" \
   > lb-config.json
 
 jq '.spec |= (
@@ -368,10 +365,10 @@ jq '.spec |= (
 )' lb-config.json > lb-config-updated.json
 
 curl -s -X PUT \
-  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
   -H "Content-Type: application/json" \
   -d @lb-config-updated.json \
-  "${F5XC_API_URL}/api/config/namespaces/${F5XC_NAMESPACE}/http_loadbalancers/${F5XC_LB_NAME}" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx" \
   | jq '.spec.client_side_defense'
 ```
 
@@ -383,7 +380,7 @@ When using `js_insert_all_pages_except` or `js_insertion_rules`, each rule match
 
 | Field | Example |
 | --- | --- |
-| `any_domain: {}` | All domains |
+| `any_domain: \{\}` | All domains |
 | `domain.exact_value` | `"app.example.com"` |
 | `domain.suffix_value` | `".example.com"` |
 | `domain.regex_value` | `".*\\.example\\.com"` |

--- a/docs/attack-scripts.mdx
+++ b/docs/attack-scripts.mdx
@@ -1,7 +1,7 @@
 ---
 title: Attack Script Library
 sidebar:
-  order: 8
+  order: 9
   label: Attack Script Library
 ---
 

--- a/docs/diagnostics.mdx
+++ b/docs/diagnostics.mdx
@@ -1,0 +1,549 @@
+---
+title: Diagnostics & Monitoring
+sidebar:
+  order: 8
+  label: Diagnostics & Monitoring
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+This page provides **API-based diagnostic commands** for verifying that traffic is reaching your HTTP load balancer, inspecting CSD telemetry (scripts, domains, form fields), and running health checks on infrastructure state. Each command produces readable terminal output using `jq`.
+
+These commands are the **API equivalent** of the [CSD Console Walkthrough](/csd/csd-console/) — use them when you need to check status from the terminal, automate monitoring, or demonstrate CSD capabilities without the UI.
+
+## Prerequisites
+
+Set up your environment variables as described in [API Automation &mdash; Environment Setup](/csd/api-automation/#environment-setup):
+
+```bash
+set -a && source .env && set +a
+```
+
+All commands below use the `xTOKENx` placeholder format. Substitute with your environment variables (`$F5XC_API_TOKEN`, `$F5XC_NAMESPACE`, etc.) or use the interactive form at the top of the page.
+
+## Time Range Helpers
+
+Many CSD endpoints require epoch timestamps (seconds since Unix epoch). These one-liners compute start/end times for common ranges.
+
+**Cross-platform** (macOS + Linux):
+
+```bash
+# Current time as epoch seconds
+NOW=$(date +%s)
+
+# 1 hour ago
+START_1H=$(( NOW - 3600 ))
+
+# 24 hours ago
+START_24H=$(( NOW - 86400 ))
+
+# 7 days ago
+START_7D=$(( NOW - 604800 ))
+
+# 30 days ago
+START_30D=$(( NOW - 2592000 ))
+```
+
+| Preset | Seconds | Shell expression |
+| --- | --- | --- |
+| 1 hour | 3,600 | `$(( $(date +%s) - 3600 ))` |
+| 24 hours | 86,400 | `$(( $(date +%s) - 86400 ))` |
+| 7 days | 604,800 | `$(( $(date +%s) - 604800 ))` |
+| 30 days | 2,592,000 | `$(( $(date +%s) - 2592000 ))` |
+
+<Aside type="note">
+CSD endpoints (`/api/shape/csd/`) use **epoch seconds** (e.g., `1710000000`). Access log endpoints (`/api/data/`) use **ISO 8601** timestamps (e.g., `2024-03-10T00:00:00Z`). The commands in each section use the correct format for that endpoint.
+</Aside>
+
+## Load Balancer Traffic
+
+Use the access log API to verify that HTTP requests are reaching your load balancer. Zero results here means traffic is not arriving — skip to [Health Checks](#health-checks) to diagnose.
+
+### Request Count (Last 24 Hours)
+
+Count total requests received by the load balancer in the past 24 hours:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "xF5XC_NAMESPACEx",
+    "query": {
+      "start_time": "'"$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)"'",
+      "end_time": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    },
+    "aggs": {
+      "total_requests": {
+        "value_count": {
+          "field": "@timestamp"
+        }
+      }
+    }
+  }' \
+  "xF5XC_API_URLx/api/data/namespaces/xF5XC_NAMESPACEx/access_logs/aggregation" \
+  | jq '{total_requests: .aggs.total_requests.value}'
+```
+
+<Aside type="caution">
+If the result is `0` or the response contains no aggregation data, traffic is not reaching the load balancer. Check [Health Checks](#health-checks) to verify DNS resolution, LB state, and certificate status before investigating CSD telemetry.
+</Aside>
+
+### Status Code Distribution
+
+Break down responses by status code class to spot errors:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "xF5XC_NAMESPACEx",
+    "query": {
+      "start_time": "'"$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)"'",
+      "end_time": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    },
+    "aggs": {
+      "status_codes": {
+        "terms": {
+          "field": "rsp_code_class"
+        }
+      }
+    }
+  }' \
+  "xF5XC_API_URLx/api/data/namespaces/xF5XC_NAMESPACEx/access_logs/aggregation" \
+  | jq -r '
+    ["STATUS_CLASS", "COUNT"],
+    (.aggs.status_codes.buckets[] | [.key, .doc_count])
+    | @tsv' | column -t
+```
+
+Expected output for a healthy site:
+
+```
+STATUS_CLASS  COUNT
+2xx           142
+3xx           18
+```
+
+A high `4xx` or `5xx` count indicates client or server errors worth investigating.
+
+### Recent Request Samples
+
+Fetch the 10 most recent access log entries to inspect individual requests:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "namespace": "xF5XC_NAMESPACEx",
+    "query": {
+      "start_time": "'"$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)"'",
+      "end_time": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+    },
+    "sort": "desc",
+    "limit": 10
+  }' \
+  "xF5XC_API_URLx/api/data/namespaces/xF5XC_NAMESPACEx/access_logs" \
+  | jq -r '
+    ["TIMESTAMP", "METHOD", "PATH", "STATUS", "SRC_IP"],
+    (.logs[] | [.timestamp, .method, .req_path, .rsp_code, .src_ip])
+    | @tsv' | column -t
+```
+
+### Access Log Field Reference
+
+| Field | Description |
+| --- | --- |
+| `@timestamp` | Request timestamp (ISO 8601) |
+| `method` | HTTP method (GET, POST, etc.) |
+| `req_path` | Request URI path |
+| `rsp_code` | HTTP response status code (e.g., 200, 404) |
+| `rsp_code_class` | Status code class (2xx, 3xx, 4xx, 5xx) |
+| `src_ip` | Client source IP address |
+| `dst_ip` | Destination (VIP) IP address |
+| `domain` | Request Host header value |
+| `user_agent` | Client User-Agent string |
+| `rsp_size` | Response body size in bytes |
+| `duration` | Request duration in milliseconds |
+
+## CSD Telemetry
+
+These commands query the same data displayed in the [CSD Console](/csd/csd-console/) dashboard, script list, form fields, and network views.
+
+### CSD Status Overview
+
+Verify that CSD is configured and enabled for the tenant:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/status" \
+  | jq '{isConfigured, isEnabled}'
+```
+
+Both values must be `true` for CSD telemetry to function. If `isConfigured` is `false`, CSD has not been enabled for this tenant — contact your F5 XC administrator.
+
+### Script Inventory
+
+List all detected scripts with risk level, status, and field/user counts. This is the API equivalent of the [Script Inventory](/csd/csd-console/#script-inventory) in the console.
+
+```bash
+NOW=$(date +%s)
+START=$(( NOW - 604800 ))
+
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"startTime\": \"${START}\",
+    \"endTime\": \"${NOW}\"
+  }" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts" \
+  | jq -r '
+    ["SCRIPT", "RISK", "STATUS", "FIELDS", "USERS"],
+    (.scripts[] | [
+      (.name | if length > 50 then .[:47] + "..." else . end),
+      .risk,
+      .status,
+      (.formFieldsCount // 0),
+      (.affectedUsersCount // 0)
+    ])
+    | @tsv' | column -t
+```
+
+<Aside type="tip">
+Script names are full URLs and can be very long. The command above truncates names to 50 characters for terminal readability. Remove the truncation filter to see full URLs.
+</Aside>
+
+### Detected Domains
+
+View the domain summary and list all detected script source domains. This is the API equivalent of the [Dashboard](/csd/csd-console/#dashboard) domain table.
+
+```bash
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/detected_domains" \
+  | jq '{
+    summary: .domain_summary,
+    domains: [.domains_list[] | {
+      domain: .domain,
+      category: .category,
+      status: .status,
+      last_seen: .last_seen
+    }]
+  }'
+```
+
+### Form Field Inventory
+
+List all form fields that CSD detected scripts reading, with sensitivity classification. This is the API equivalent of the [Form Fields](/csd/csd-console/#form-fields) view.
+
+```bash
+NOW=$(date +%s)
+START=$(( NOW - 604800 ))
+
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/formFields?startTime=${START}&endTime=${NOW}" \
+  | jq -r '
+    ["FIELD", "SENSITIVITY", "SCRIPTS"],
+    (.form_fields[] | [
+      .name,
+      .analysis,
+      (.scripts_count // 0)
+    ])
+    | @tsv' | column -t
+```
+
+### Script Deep Dive
+
+For a specific script, retrieve its dashboard overview, behaviors, and network interactions. First, get a script ID from the script inventory above, then query its details:
+
+```bash
+SCRIPT_ID="your-script-id"
+
+# Overview (risk level, type, source domain)
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/dashboard" \
+  | jq '{name, risk, type, source_domain, status}'
+
+# Behaviors over time
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/behaviors" \
+  | jq '.behaviors'
+
+# Network interactions (domains the script communicates with)
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/networkInteractions" \
+  | jq '.network_interactions'
+```
+
+### Affected Users
+
+List users impacted by a specific script. This is the API equivalent of the [Affected Users](/csd/csd-console/#affected-users) tab.
+
+```bash
+SCRIPT_ID="your-script-id"
+NOW=$(date +%s)
+START=$(( NOW - 604800 ))
+
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"startTime\": \"${START}\",
+    \"endTime\": \"${NOW}\"
+  }" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/scripts/${SCRIPT_ID}/affectedUsers" \
+  | jq -r '
+    ["IP_ADDRESS", "DEVICE_ID", "GEO", "CHANNEL", "USER_AGENT"],
+    (.affected_users[] | [
+      .ip_address,
+      (.device_id | if length > 12 then .[:12] + "..." else . end),
+      .geolocation,
+      .channel,
+      (.user_agent | if length > 30 then .[:27] + "..." else . end)
+    ])
+    | @tsv' | column -t
+```
+
+### CSD Telemetry Field Reference
+
+| Field | Endpoint | Description |
+| --- | --- | --- |
+| `isConfigured` | status | CSD enabled at tenant level |
+| `isEnabled` | status | CSD active for this namespace |
+| `scripts[]` | scripts | Array of detected script objects |
+| `.name` | scripts | Full URL of the JavaScript file |
+| `.risk` | scripts | Risk level (No Risk, Low Risk, High Risk) |
+| `.status` | scripts | AN (Action Needed) or NA (No Action Needed) |
+| `.formFieldsCount` | scripts | Number of form fields the script reads |
+| `.affectedUsersCount` | scripts | Number of unique users/sessions affected |
+| `domain_summary` | detected_domains | Counts by status (action_needed, allowed, mitigated, total) |
+| `domains_list[]` | detected_domains | Array of detected domain objects |
+| `form_fields[]` | formFields | Array of detected form field objects |
+| `.analysis` | formFields | Sensitivity classification (Sensitive, Not Sensitive) |
+
+## Health Checks
+
+Run these commands to verify that your load balancer, certificate, CSD configuration, and DNS are all healthy.
+
+### Load Balancer and Certificate State
+
+Check the LB operational state and TLS certificate status:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx" \
+  | jq '{
+    state: .spec.state,
+    cert_state: .spec.auto_cert_state,
+    domains: .spec.domains,
+    csd_enabled: (if .spec.client_side_defense then true else false end)
+  }'
+```
+
+| Field | Healthy | Problem |
+| --- | --- | --- |
+| `state` | `VIRTUAL_HOST_READY` | `VIRTUAL_HOST_PENDING_A_RECORD` &mdash; DNS A record not configured |
+| `cert_state` | `AutoCertIssued` or `AutoCertRenewing` | `PreDomainChallengePending` &mdash; ACME challenge CNAME missing |
+| `csd_enabled` | `true` | `false` &mdash; CSD not enabled on LB |
+
+### CSD and JS Configuration
+
+Verify CSD is enabled and the JavaScript injection tag is configured:
+
+```bash
+# CSD status
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/status" \
+  | jq '{isConfigured, isEnabled}'
+
+# JS injection tag
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/js_configuration" \
+  | jq '{has_script_tag: (.scriptTag | length > 0)}'
+```
+
+### DNS Resolution
+
+Verify that DNS records are resolving correctly:
+
+```bash
+# A record — should return the VIP IP
+dig +short xF5XC_DOMAINNAMEx A
+
+# ACME challenge CNAME — required for automatic TLS
+dig +short _acme-challenge.xF5XC_DOMAINNAMEx CNAME
+```
+
+### Combined Health Dashboard
+
+Run a single command that checks all health indicators and produces a summary table:
+
+```bash
+echo "=== CSD Health Dashboard ==="
+echo ""
+
+# LB state
+LB=$(curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx")
+
+LB_STATE=$(echo "$LB" | jq -r '.spec.state // "UNKNOWN"')
+CERT_STATE=$(echo "$LB" | jq -r '.spec.auto_cert_state // "UNKNOWN"')
+CSD_ON_LB=$(echo "$LB" | jq -r 'if .spec.client_side_defense then "ENABLED" else "DISABLED" end')
+DOMAINS=$(echo "$LB" | jq -r '.spec.domains | join(", ")')
+
+# CSD status
+CSD=$(curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/status")
+
+CSD_CONFIGURED=$(echo "$CSD" | jq -r '.isConfigured // false')
+CSD_ENABLED=$(echo "$CSD" | jq -r '.isEnabled // false')
+
+# JS config
+JS_TAG=$(curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/js_configuration" \
+  | jq -r 'if (.scriptTag | length) > 0 then "PRESENT" else "MISSING" end')
+
+# DNS
+DNS_A=$(dig +short xF5XC_DOMAINNAMEx A | head -1)
+DNS_ACME=$(dig +short _acme-challenge.xF5XC_DOMAINNAMEx CNAME | head -1)
+
+printf "%-24s %s\n" "CHECK" "STATUS"
+printf "%-24s %s\n" "------------------------" "----------------------------"
+printf "%-24s %s\n" "LB State" "$LB_STATE"
+printf "%-24s %s\n" "Certificate" "$CERT_STATE"
+printf "%-24s %s\n" "CSD on LB" "$CSD_ON_LB"
+printf "%-24s %s\n" "CSD Configured (tenant)" "$CSD_CONFIGURED"
+printf "%-24s %s\n" "CSD Enabled" "$CSD_ENABLED"
+printf "%-24s %s\n" "JS Script Tag" "$JS_TAG"
+printf "%-24s %s\n" "DNS A Record" "${DNS_A:-NOT_FOUND}"
+printf "%-24s %s\n" "ACME CNAME" "${DNS_ACME:-NOT_FOUND}"
+printf "%-24s %s\n" "Domains" "$DOMAINS"
+```
+
+### Health Status Reference
+
+| Check | Healthy | Problem | Fix |
+| --- | --- | --- | --- |
+| LB State | `VIRTUAL_HOST_READY` | `VIRTUAL_HOST_PENDING_A_RECORD` | Configure DNS A record &mdash; see [API Automation &mdash; Step 4](/csd/api-automation/#step-4-configure-dns) |
+| Certificate | `AutoCertIssued` | `PreDomainChallengePending` | Add ACME challenge CNAME: `_acme-challenge.&lt;domain&gt;` &rarr; `*.autocerts.ves.volterra.io` |
+| CSD on LB | `ENABLED` | `DISABLED` | Enable CSD on the load balancer &mdash; see [API Reference](/csd/api-reference/#enable-csd-on-a-load-balancer) |
+| CSD Configured | `true` | `false` | Contact F5 XC administrator to enable CSD for the tenant |
+| CSD Enabled | `true` | `false` | CSD not active &mdash; check tenant configuration |
+| JS Script Tag | `PRESENT` | `MISSING` | Verify CSD is enabled and protected domain is registered |
+| DNS A Record | VIP IP address | `NOT_FOUND` | Create A record pointing to LB VIP &mdash; see [API Automation &mdash; Step 4](/csd/api-automation/#step-4-configure-dns) |
+| ACME CNAME | `*.autocerts...` | `NOT_FOUND` | Create CNAME for `_acme-challenge.&lt;domain&gt;` |
+
+## Troubleshooting
+
+### Zero Access Logs
+
+If the [Request Count](#request-count-last-24-hours) returns `0`:
+
+<Steps>
+1. **Check DNS resolution** &mdash; verify the domain resolves to the LB VIP:
+   ```bash
+   dig +short xF5XC_DOMAINNAMEx A
+   ```
+   If empty, DNS is not configured. See [API Automation &mdash; Step 4](/csd/api-automation/#step-4-configure-dns).
+
+2. **Check LB state** &mdash; the load balancer must be `VIRTUAL_HOST_READY`:
+   ```bash
+   curl -s \
+     -H "Authorization: APIToken xF5XC_API_TOKENx" \
+     "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx" \
+     | jq '.spec.state'
+   ```
+
+3. **Send a test request** &mdash; generate traffic to confirm end-to-end connectivity:
+   ```bash
+   curl -sv "https://xF5XC_DOMAINNAMEx/" 2>&1 | head -20
+   ```
+   Look for a successful TLS handshake and HTTP response.
+</Steps>
+
+### LB Stuck in VIRTUAL_HOST_PENDING_A_RECORD
+
+The load balancer is waiting for a DNS A record pointing to its VIP. See [API Automation &mdash; LB Stuck in VIRTUAL_HOST_PENDING_A_RECORD](/csd/api-automation/#lb-stuck-in-virtual_host_pending_a_record) for detailed resolution steps.
+
+### Certificate Stuck in PreDomainChallengePending
+
+The automatic TLS certificate requires an ACME challenge CNAME record:
+
+```
+_acme-challenge.xF5XC_DOMAINNAMEx  CNAME  *.autocerts.ves.volterra.io
+```
+
+Verify the CNAME exists:
+
+```bash
+dig +short _acme-challenge.xF5XC_DOMAINNAMEx CNAME
+```
+
+If empty, create the CNAME at your DNS provider. Certificate provisioning takes 2&ndash;5 minutes after the CNAME is in place.
+
+### CSD isConfigured is false
+
+CSD must be enabled at the tenant level by an F5 XC administrator. This is a tenant-wide setting that cannot be configured via the namespace API. Contact your administrator to enable Client-Side Defense.
+
+### Empty Scripts Array
+
+If the [Script Inventory](#script-inventory) returns an empty array:
+
+<Steps>
+1. **Check the protected domain** &mdash; CSD monitors scripts only on registered domains:
+   ```bash
+   curl -s \
+     -H "Authorization: APIToken xF5XC_API_TOKENx" \
+     "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains" \
+     | jq '.items[].spec.protected_domain'
+   ```
+
+2. **Verify JS injection** &mdash; confirm the CSD script tag is being injected into pages:
+   ```bash
+   curl -s "https://xF5XC_DOMAINNAMEx/" | grep -o 'shape.com[^"]*' | head -1
+   ```
+   If no match, CSD JavaScript is not being injected. Check that the LB has `client_side_defense` enabled.
+
+3. **Allow processing time** &mdash; after first enabling CSD or registering a new protected domain, script detection can take 5&ndash;15 minutes. Generate traffic to the site and wait before re-checking.
+</Steps>
+
+## Quick Reference
+
+### Time Range Presets
+
+| Period | Epoch offset | ISO 8601 (Linux) | ISO 8601 (macOS) |
+| --- | --- | --- | --- |
+| 1 hour | `$(( $(date +%s) - 3600 ))` | `date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ` | `date -u -v-1H +%Y-%m-%dT%H:%M:%SZ` |
+| 24 hours | `$(( $(date +%s) - 86400 ))` | `date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ` | `date -u -v-24H +%Y-%m-%dT%H:%M:%SZ` |
+| 7 days | `$(( $(date +%s) - 604800 ))` | `date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ` | `date -u -v-7d +%Y-%m-%dT%H:%M:%SZ` |
+| 30 days | `$(( $(date +%s) - 2592000 ))` | `date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ` | `date -u -v-30d +%Y-%m-%dT%H:%M:%SZ` |
+
+### Endpoint Summary
+
+| Diagnostic | Endpoint | Method | Time Format |
+| --- | --- | --- | --- |
+| Request count | `/api/data/namespaces/\{ns\}/access_logs/aggregation` | POST | ISO 8601 |
+| Status codes | `/api/data/namespaces/\{ns\}/access_logs/aggregation` | POST | ISO 8601 |
+| Recent requests | `/api/data/namespaces/\{ns\}/access_logs` | POST | ISO 8601 |
+| CSD status | `/api/shape/csd/namespaces/\{ns\}/status` | GET | None |
+| Script list | `/api/shape/csd/namespaces/\{ns\}/scripts` | POST | Epoch seconds |
+| Detected domains | `/api/shape/csd/namespaces/\{ns\}/detected_domains` | GET | None |
+| Form fields | `/api/shape/csd/namespaces/\{ns\}/formFields` | GET | Epoch seconds (query params) |
+| Script details | `/api/shape/csd/namespaces/\{ns\}/scripts/\{id\}/dashboard` | GET | None |
+| Affected users | `/api/shape/csd/namespaces/\{ns\}/scripts/\{id\}/affectedUsers` | POST | Epoch seconds |
+| LB state | `/api/config/namespaces/\{ns\}/http_loadbalancers/\{name\}` | GET | None |
+| JS configuration | `/api/shape/csd/namespaces/\{ns\}/js_configuration` | GET | None |

--- a/docs/references.mdx
+++ b/docs/references.mdx
@@ -1,7 +1,7 @@
 ---
 title: References
 sidebar:
-  order: 10
+  order: 11
 ---
 
 ## Documentation


### PR DESCRIPTION
## Summary
- Adds a new **Diagnostics & Monitoring** documentation page (sidebar order 8) with API-based commands for verifying LB traffic, inspecting CSD telemetry (scripts, domains, form fields), and running health checks from the terminal
- Converts `api-reference.mdx` from `${F5XC_...}` shell variable style to `xF5XC_...x` placeholder format, matching `api-automation.mdx` for interactive form compatibility
- Bumps sidebar order for `attack-scripts.mdx` (8→9), `api-reference.mdx` (9→10), and `references.mdx` (10→11)

### New page sections
- **Time Range Helpers** — cross-platform epoch arithmetic with preset table
- **Load Balancer Traffic** — access log queries (request count, status codes, recent samples)
- **CSD Telemetry** — status, scripts, detected domains, form fields, script deep dive, affected users
- **Health Checks** — LB state, cert state, CSD config, DNS, combined health dashboard
- **Troubleshooting** — zero access logs, pending LB, pending cert, unconfigured CSD, empty scripts
- **Quick Reference** — time range presets and endpoint summary tables

### Placeholder consistency fix
The `api-reference.mdx` page used `${F5XC_API_TOKEN}` / `${F5XC_NAMESPACE}` style variables in curl commands, which are not compatible with the interactive placeholder form that substitutes `xF5XC_...x` tokens. All curl examples now use the `xTOKENx` format consistent with `api-automation.mdx`.

Closes #247

## Test plan
- [ ] Verify all 11 pages render in correct sidebar order (0–11) with no gaps
- [ ] Confirm `diagnostics.mdx` renders without MDX compilation errors
- [ ] Verify cross-references to `api-automation`, `csd-console`, and `api-reference` pages resolve correctly
- [ ] Confirm interactive placeholder form substitutes `xF5XC_...x` tokens on both `diagnostics.mdx` and `api-reference.mdx`
- [ ] Test at least one curl command from each section against a live tenant


🤖 Generated with [Claude Code](https://claude.com/claude-code)