### PR TITLE
docs: flush UAT learnings into repository documentation

### DIFF
--- a/docs/api-automation.mdx
+++ b/docs/api-automation.mdx
@@ -58,6 +58,12 @@ set -a && source .env && set +a
 
 <Aside type="tip">
 If your API token contains `/` or `=` characters, wrap the value in single quotes in `.env` (e.g., `F5XC_API_TOKEN='abc/def='`) to prevent shell interpretation issues when sourcing.
+
+Some container runtimes and secret managers inject literal quote characters into environment variable values. If API calls return `401 Unauthorized` despite a valid token, strip stray quotes before use:
+
+```bash
+export F5XC_API_TOKEN=$(echo "$F5XC_API_TOKEN" | tr -d "'")
+```
 </Aside>
 
 Each `xTOKENx` placeholder in the curl commands below maps directly to an environment variable — for example, `xF5XC_API_TOKENx` corresponds to `$F5XC_API_TOKEN`. You can substitute these values using the interactive form at the top of the page, or let an AI assistant like Claude Code read your `.env` and build the commands for you.
@@ -297,7 +303,7 @@ A `200` response confirms the load balancer was created with CSD enabled.
 After creating the load balancer, it enters `VIRTUAL_HOST_PENDING_A_RECORD` status and the automatic certificate stays in `PreDomainChallengePending`. Two DNS records must exist before the LB becomes fully operational:
 
 1. **A record** — `xF5XC_DOMAINNAMEx` pointing to the VIP IP address (from `dns_info` in the LB response)
-2. **ACME challenge CNAME** — `_acme-challenge.xF5XC_DOMAINNAMEx` pointing to `*.autocerts.ves.volterra.io`
+2. **ACME challenge record** — `_acme-challenge.xF5XC_DOMAINNAMEx` for TLS certificate validation (managed automatically when using F5 XC DNS with managed records; manual CNAME required for external DNS)
 
 The approach depends on whether F5 XC is the authoritative DNS provider for your domain.
 
@@ -355,7 +361,11 @@ echo "$ZONE_CONFIG" \
   | jq .
 ```
 
-A `200` response confirms the zone was updated. F5 XC will immediately create the A record and ACME challenge CNAME in the zone's auto-managed record group.
+<Aside type="caution">
+The zone spec contains an `x-ves-io-managed` rr_set_group with platform-managed records. Your `PUT` payload **must preserve this group** — omitting it causes HTTP 403 "reserved for internal purposes". Always retrieve the current zone configuration with `GET` first, modify only the fields you need, and send back the complete spec.
+</Aside>
+
+A `200` response confirms the zone was updated. F5 XC will immediately create the A record and ACME challenge record in the zone's auto-managed record group.
 
 **3. Verify DNS resolution:**
 
@@ -364,6 +374,15 @@ dig +short xF5XC_DOMAINNAMEx A
 ```
 
 The response should return the VIP IP address. DNS propagation is typically immediate for F5 XC managed zones, but allow up to 60 seconds.
+
+<Aside type="tip">
+**Negative DNS cache:** If you queried the domain before the record existed, your recursive resolver may have cached the `NXDOMAIN` response. Verify against the authoritative nameserver or a public resolver to rule out stale cache:
+
+```bash
+dig +short xF5XC_DOMAINNAMEx A @ns1.f5clouddns.com
+dig +short xF5XC_DOMAINNAMEx A @8.8.8.8
+```
+</Aside>
 
 ### Option B: External DNS Provider
 
@@ -474,7 +493,7 @@ curl -s \
 | `cert_state` | `AutoCertIssued` or `AutoCertRenewing` | `PreDomainChallengePending` — ACME CNAME missing |
 
 <Aside type="note">
-Certificate provisioning can take several minutes after DNS records are created. If `cert_state` is still pending, wait 2–5 minutes and check again.
+Certificate provisioning can take **5–10 minutes** after DNS records are created. If `cert_state` is still pending, wait and check again. The platform checks DNS on its own schedule — the LB may remain in `VIRTUAL_HOST_PENDING_A_RECORD` for several minutes even after the A record is confirmed at the authoritative nameserver.
 </Aside>
 
 ### JS Configuration
@@ -526,14 +545,15 @@ curl -s \
 
 ## Teardown
 
-Remove namespace-scoped objects in **reverse creation order** — delete objects that depend on other objects first:
+Remove objects in **reverse creation order** — delete objects that depend on other objects first:
 
 1. **HTTP Load Balancer** — depends on Origin Pool
 2. **Origin Pool** — depends on Healthcheck (if created)
-3. **Healthcheck** — only if created in Step 1
+3. **DNS zone cleanup** — managed records (A and ACME) auto-clean when the LB is deleted; manual records in `default_rr_set_group` need manual cleanup via `PUT`
+4. **Healthcheck** — only if created in Step 1
 
 <Aside type="caution">
-**Do not delete the protected domain.** Protected domains are tenant-scoped and persistent — they are shared infrastructure, not per-deployment resources. Deleting a protected domain would affect all load balancers on the tenant that use that domain for CSD monitoring.
+**Do not delete the protected domain or the DNS zone.** Protected domains are tenant-scoped and persistent — they are shared infrastructure, not per-deployment resources. The DNS zone is also shared infrastructure and should not be deleted. Only clean up records you added manually to the `default_rr_set_group`.
 </Aside>
 
 ### Delete HTTP Load Balancer
@@ -651,7 +671,7 @@ The `single_lb_app` object has its own required `oneOf` groups. Setting `single_
 
 ### Teardown Order
 
-Delete namespace-scoped objects in reverse: HTTP load balancer &rarr; origin pool &rarr; healthcheck (if created). Do **not** delete the protected domain — it is tenant-scoped and persistent.
+Delete objects in reverse: HTTP load balancer &rarr; origin pool &rarr; DNS zone cleanup (manual records only) &rarr; healthcheck (if created). Do **not** delete the protected domain or DNS zone — both are shared infrastructure.
 
 ### Error Handling
 
@@ -716,6 +736,21 @@ CSD must be enabled at the tenant level. Contact your F5 XC administrator to ena
 ### Protected Domain Registration Returns 409
 
 A `409` with "domain already exists (in uriList)" means the root domain is already registered on the tenant. Protected domains are **tenant-scoped** — they do not belong to any single namespace. This is a success condition: the domain is already protected and no further action is needed. Continue to Step 7.
+
+### Certificate Stuck — Clean Recreation
+
+When the certificate is stuck in `DomainChallengePending` or `PreDomainChallengePending` for more than 15 minutes, the fastest recovery path is to delete the LB and origin pool, then recreate them from scratch. With the DNS zone already configured (managed records enabled), the clean recreation typically produces `VIRTUAL_HOST_READY` with `CertificateValid` in 5–7 minutes.
+
+1. Delete the HTTP Load Balancer (Step: Teardown)
+2. Delete the Origin Pool (Step: Teardown)
+3. Wait 30 seconds for platform cleanup
+4. Recreate the Origin Pool (Step 2)
+5. Recreate the HTTP Load Balancer (Step 3)
+6. Monitor certificate state (Step 7) — expect `CertificateValid` within 5–10 minutes
+
+<Aside type="tip">
+You do not need to reconfigure the DNS zone or re-register the protected domain. These are persistent resources that survive LB deletion.
+</Aside>
 
 ## OpenAPI Reference
 

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -25,6 +25,32 @@ All curl examples use the `xTOKENx` placeholder format. Substitute with your env
 -H "Authorization: APIToken xF5XC_API_TOKENx"
 ```
 
+## API Conventions
+
+<Aside type="note">
+These conventions apply to all F5 XC configuration and CSD API endpoints. Understanding them prevents common automation mistakes.
+</Aside>
+
+### Response Bodies
+
+- **POST** returns the created object as JSON.
+- **PUT** and **DELETE** return an empty `\{\}` on HTTP 200 — this is normal, not an error. Do not treat an empty response body as a failure.
+
+### List vs GET Endpoints
+
+List endpoints (e.g., `/healthchecks`, `/origin_pools`, `/protected_domains`) and individual GET endpoints (e.g., `/healthchecks/\{name\}`) return **different response structures**:
+
+| Endpoint type | Example path | Response structure |
+| --- | --- | --- |
+| **List** | `/origin_pools` | Items have top-level `.name`, `.namespace`, `.tenant` with `metadata: null` and `get_spec: null` |
+| **Individual GET** | `/origin_pools/\{name\}` | Object has `.metadata.name`, `.spec.*` with full configuration |
+
+Use the correct `jq` paths for each. For example, to extract names from a list endpoint use `.items[].name`, not `.items[].metadata.name`.
+
+### Protected Domain Identifier
+
+For protected domain GET and DELETE operations, the `\{name\}` path parameter is the **domain value itself** (e.g., `bankexample.com`), not an arbitrary object name. This differs from other F5 XC objects where the name is a user-chosen identifier.
+
 ## CSD API Endpoints
 
 Base path: `/api/shape/csd/namespaces/\{namespace\}/`

--- a/docs/diagnostics.mdx
+++ b/docs/diagnostics.mdx
@@ -21,6 +21,12 @@ set -a && source .env && set +a
 
 All commands below use the `xTOKENx` placeholder format. Substitute with your environment variables (`$F5XC_API_TOKEN`, `$F5XC_NAMESPACE`, etc.) or use the interactive form at the top of the page.
 
+## API Behavior Notes
+
+<Aside type="note">
+**PUT and DELETE return empty `\{\}`** on HTTP 200 — this is the expected success response, not an error. Only **POST** returns the created object. **List endpoints** (e.g., `/healthchecks`) and **individual GET endpoints** (e.g., `/healthchecks/\{name\}`) return different response structures — see [API Reference &mdash; API Conventions](/csd/api-reference/#api-conventions) for details on the correct `jq` paths for each.
+</Aside>
+
 ## Time Range Helpers
 
 Many CSD endpoints require epoch timestamps (seconds since Unix epoch). These one-liners compute start/end times for common ranges.
@@ -87,6 +93,10 @@ dig +short xF5XC_DOMAINNAMEx A
 | **FAIL** &mdash; empty response | DNS A record not configured |
 
 **Fix:** [API Automation &mdash; Step 4: Configure DNS](/csd/api-automation/#step-4-configure-dns)
+
+<Aside type="tip">
+**Negative DNS cache:** If the domain previously returned `NXDOMAIN`, recursive resolvers may cache that result. Verify against the authoritative nameserver to rule out stale cache: `dig +short xF5XC_DOMAINNAMEx A @ns1.f5clouddns.com` or use a public resolver like `@8.8.8.8`.
+</Aside>
 
 ### DNS-2: ACME Challenge Record
 
@@ -169,7 +179,7 @@ curl -s \
 | **WARN** &mdash; `"DomainChallengePending"` or `"DomainChallengeStarted"` | ACME challenge in progress &mdash; wait 5&ndash;10 minutes |
 | **FAIL** &mdash; `"PreDomainChallengePending"` | ACME challenge record missing &mdash; see [DNS-2](#dns-2-acme-challenge-record) |
 
-**Fix:** Add the ACME CNAME record. Certificate provisioning takes 2&ndash;5 minutes after the CNAME is in place.
+**Fix:** Ensure the ACME challenge record is in place (CNAME for external DNS, or enable managed records for F5 XC DNS). Certificate provisioning takes **5&ndash;10 minutes** after the record is configured. If stuck beyond 15 minutes, see [Certificate Stuck &mdash; Clean Recreation](/csd/api-automation/#certificate-stuck--clean-recreation).
 
 ### TLS-2: Certificate Details
 


### PR DESCRIPTION
## Summary

- Add **API Conventions** section to `api-reference.mdx` (response bodies, list vs GET structures, protected domain identifier)
- Fix factual errors in `api-automation.mdx` (ACME record type, cert timing 2-5 → 5-10 min)
- Add operational warnings: token quoting, zone update safety, DNS negative cache, LB state timing
- Expand teardown with DNS zone cleanup step and clean recreation troubleshooting
- Add API behavior notes and DNS cache tip to `diagnostics.mdx`

## Test plan

- [ ] Verify MDX syntax is valid (no bare `<`, no unescaped `{}`)
- [ ] Confirm cross-references between pages resolve correctly
- [ ] Review all timing and factual claims against UAT discoveries

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)