### PR TITLE
fix: remove custom anchor IDs with curly braces from MDX files

### DIFF
--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -97,7 +97,7 @@ If any step returns FAIL, stop and report the failure with the relevant troubles
 - `curl` and `jq` installed locally
 - A namespace with permissions to create healthchecks, origin pools, and HTTP load balancers
 
-## Environment Setup {#environment-setup}
+## Environment Setup
 
 Create a `.env` file with your environment values. A template is provided in the repository:
 
@@ -259,7 +259,7 @@ The `single_lb_app` object has its own required `oneOf` groups. Setting `single_
 
 ## Troubleshooting
 
-### Healthcheck Not Linked to Origin Pool {#healthcheck-not-linked-to-origin-pool}
+### Healthcheck Not Linked to Origin Pool
 
 If Phase 1 Step 2 (Verify Healthcheck is Linked) shows an empty array `[]`:
 
@@ -267,7 +267,7 @@ If Phase 1 Step 2 (Verify Healthcheck is Linked) shows an empty array `[]`:
 2. Verify the healthcheck exists: `GET /api/config/namespaces/{namespace}/healthchecks/{hc_name}`
 3. Recreate the origin pool with the correct healthcheck reference
 
-### LB Stuck in VIRTUAL_HOST_PENDING_A_RECORD {#lb-stuck-in-virtual_host_pending_a_record}
+### LB Stuck in VIRTUAL_HOST_PENDING_A_RECORD
 
 If the load balancer `state` remains `VIRTUAL_HOST_PENDING_A_RECORD` after Phase 1 Step 4:
 
@@ -312,7 +312,7 @@ CSD must be enabled at the tenant level. Contact your F5 XC administrator to ena
 
 A `409` with "domain already exists (in uriList)" means the root domain is already registered on the tenant. Protected domains are **tenant-scoped** — they do not belong to any single namespace. This is a success condition: the domain is already protected and no further action is needed. Continue to Phase 1 Step 7.
 
-### Certificate Stuck — Clean Recreation {#certificate-stuck--clean-recreation}
+### Certificate Stuck — Clean Recreation
 
 When the certificate is stuck in `DomainChallengePending` or `PreDomainChallengePending` for more than 15 minutes, the fastest recovery path is to delete the LB and origin pool, then recreate them from scratch. With the DNS zone already configured (managed records enabled), the clean recreation typically produces `VIRTUAL_HOST_READY` with `CertificateValid` in 5–7 minutes.
 

--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -9,7 +9,7 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 
 Phase 1 deploys and validates the full CSD infrastructure. Complete all steps in order — each step must PASS before proceeding. Return to the [index](/csd/api-automation/) to complete Environment Setup and variable resolution before running these commands.
 
-## Step 1: Create Healthcheck (Optional) {#step-1-create-healthcheck-optional}
+## Step 1: Create Healthcheck (Optional)
 
 Create an HTTP healthcheck that the origin pool can use to monitor backend health.
 
@@ -72,7 +72,7 @@ curl -s \
 | `path` | `/` | PASS |
 | Step 1 skipped (error code `8`, limit exhausted) | — | PASS (healthcheck is optional for CSD) |
 
-## Step 2: Create Origin Pool {#step-2-create-origin-pool}
+## Step 2: Create Origin Pool
 
 Create an origin pool pointing to your backend server. If you created a healthcheck in Step 1, include the `healthcheck` reference. If Step 1 was skipped, use an empty array.
 
@@ -276,7 +276,7 @@ curl -s \
 | `state` | `VIRTUAL_HOST_PENDING_A_RECORD` | Expected at this point — DNS not yet configured |
 | `cert_state` | `PreDomainChallengePending` | Expected — ACME challenge not started |
 
-## Step 4: Configure DNS {#step-4-configure-dns}
+## Step 4: Configure DNS
 
 After creating the load balancer, it enters `VIRTUAL_HOST_PENDING_A_RECORD` status and the automatic certificate stays in `PreDomainChallengePending`. Two DNS records must exist before the LB becomes fully operational:
 
@@ -285,7 +285,7 @@ After creating the load balancer, it enters `VIRTUAL_HOST_PENDING_A_RECORD` stat
 
 The approach depends on whether F5 XC is the authoritative DNS provider for your domain.
 
-### Detect DNS Authority {#detect-dns-authority}
+### Detect DNS Authority
 
 Check the nameservers for your root domain:
 
@@ -295,7 +295,7 @@ dig +short NS xF5XC_ROOT_DOMAINx
 
 If the response includes `ns1.f5clouddns.com` and `ns2.f5clouddns.com`, F5 XC is the authoritative DNS provider — follow **Option A**. Otherwise, follow **Option B** for external DNS.
 
-### Option A: F5 XC Managed DNS {#option-a-f5-xc-managed-dns}
+### Option A: F5 XC Managed DNS
 
 When F5 XC is the authoritative DNS provider, the platform can automatically create both the A record and the ACME challenge CNAME — but only when the DNS zone has `allow_http_lb_managed_records` enabled.
 
@@ -446,7 +446,7 @@ curl -s \
 | `enabled` | `true` | PASS |
 | Either is `false` | — | FAIL — contact F5 XC administrator to enable CSD at tenant level |
 
-## Step 6: Register Protected Domain {#step-6-register-protected-domain}
+## Step 6: Register Protected Domain
 
 Register the root domain that CSD will monitor. The `protected_domain` field must be the **eTLD+1** root domain (e.g., `f5demos.com`), not the full FQDN.
 


### PR DESCRIPTION
## Summary

Closes #268

The MDX build fails because `{#id}` custom heading anchor syntax is parsed as JSX expressions. Since Starlight auto-generates matching IDs from heading text, the explicit IDs are unnecessary.

Removes `{#id}` suffixes from 10 headings across `index.mdx` and `phase-1-build.mdx`.

## Test plan

- [ ] Astro build succeeds (no acorn parse errors)
- [ ] Heading anchor links from `diagnostics.mdx` and `api-reference.mdx` still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)