### PR TITLE
docs: make browser steps AI-executable with browser automation tools

### DIFF
--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -83,7 +83,7 @@ The AI assistant follows this sequence:
 
 1. **Resolve variables** — protocol above; confirm with operator before proceeding
 2. **Execute Phase 1** (Steps 1–7) — infrastructure creation and verification; all Phase 1 checks must PASS before proceeding
-3. **Execute Phase 2** (Steps 8–9) — attack simulation (browser-based) and detection verification via API
+3. **Execute Phase 2** (Steps 8–9) — attack simulation and detection verification via API; AI assistants with browser automation execute the browser steps directly, operators without browser tools perform them manually
 4. **Execute Phase 3** — apply mitigation for all detected domains, re-run attack, verify blocking is effective
 5. **Ask operator for teardown confirmation** — present: "Phase 4 will permanently delete all deployment objects. Are you ready to tear down? Reply 'yes' to proceed." Wait for explicit approval before proceeding.
 6. **Execute Phase 4** (on approval) — delete all objects in reverse dependency order

--- a/docs/api-automation/phase-2-attack.mdx
+++ b/docs/api-automation/phase-2-attack.mdx
@@ -12,12 +12,24 @@ Phase 2 generates simulated attack traffic against the protected application and
 ## Step 8: Attack Simulation
 
 <Aside type="note">
-This step requires a **web browser** — CSD monitors JavaScript behavior inside the browser and cannot be triggered with `curl`. If you are an AI assistant without browser access, instruct the human operator to perform this step manually, or use browser automation (Playwright, Puppeteer) if available.
+This step requires browser-side JavaScript execution — `curl` cannot trigger CSD detection. AI assistants with browser automation tools (MCP Chrome DevTools, Playwright, Puppeteer) execute these steps directly using the **AI-Automated Execution** sequence below. Operators without browser automation perform the manual steps.
 </Aside>
 
 After the infrastructure is verified (all Phase 1 Step 7 checks PASS), run the attack simulation scripts to generate CSD detections. The scripts are defined in the [Trigger Detection](/csd/trigger-detection/) guide and the [Attack Script Library](/csd/attack-scripts/).
 
-### Execution Order
+### AI-Automated Execution
+
+AI assistants with browser automation tools execute the attack simulation programmatically:
+
+1. **Navigate** — `navigate_page` to `https://$F5XC_DOMAINNAME/#/login`
+2. **Snapshot** — `take_snapshot` to identify the email and password form field UIDs
+3. **Fill credentials** — `fill` the email field with `test@example.com` and the password field with `P@ssword123` (do not submit the form)
+4. **Execute script** — `evaluate_script` with the Combined Detection Script IIFE from [Trigger Detection](/csd/trigger-detection/#run-the-combined-simulation-script) — wrap it in an arrow function that returns a status object
+5. **Capture evidence** — read the `evaluate_script` return value and run `list_console_messages` to capture the full `[CSD Demo]` output
+
+### Manual Execution
+
+Operators without browser automation tools perform the steps manually:
 
 1. **Navigate** to the protected application login page: `https://xF5XC_DOMAINNAMEx/#/login`
 2. **Enter dummy credentials** — type `test@example.com` in the Email field and `P@ssword123` in the Password field (do not submit the form)
@@ -39,7 +51,7 @@ Detection takes **5–10 minutes** to appear in the CSD dashboard. Proceed to St
 
 ### Evidence
 
-The AI assistant should report:
+The AI assistant should report the following. For AI-automated execution, evidence is captured programmatically via `evaluate_script` return values and `list_console_messages`. For manual execution, the operator reads the browser console output.
 
 | Check | Expected | Status |
 | --- | --- | --- |

--- a/docs/api-automation/phase-3-mitigate.mdx
+++ b/docs/api-automation/phase-3-mitigate.mdx
@@ -143,10 +143,24 @@ If any domain is missing, re-run the POST command for that domain from Step 2.
 ## Step 4: Re-run Attack Simulation
 
 <Aside type="note">
-This step requires a **web browser** — the same requirement as Phase 2 Step 8. If you are an AI assistant without browser access, instruct the human operator to perform this step manually.
+This step requires browser-side JavaScript execution — `curl` cannot trigger CSD detection. AI assistants with browser automation tools (MCP Chrome DevTools, Playwright, Puppeteer) execute these steps directly using the **AI-Automated Execution** sequence below. Operators without browser automation perform the manual steps.
 </Aside>
 
-Re-run the combined simulation script using the same procedure as [Phase 2 — Step 8: Attack Simulation](/csd/api-automation/phase-2-attack/#step-8-attack-simulation):
+Re-run the combined simulation script to verify that mitigated domains are now blocked.
+
+### AI-Automated Execution
+
+AI assistants with browser automation tools re-run the attack simulation programmatically:
+
+1. **Navigate** — `navigate_page` to `https://$F5XC_DOMAINNAME/#/login`
+2. **Snapshot** — `take_snapshot` to identify the email and password form field UIDs
+3. **Fill credentials** — `fill` the email field with `test@example.com` and the password field with `P@ssword123` (do not submit the form)
+4. **Execute script** — `evaluate_script` with the Combined Detection Script IIFE from [Trigger Detection](/csd/trigger-detection/#run-the-combined-simulation-script)
+5. **Capture evidence** — run `list_console_messages` and check for blocked/error messages on mitigated CDN domains, confirming mitigation is active
+
+### Manual Execution
+
+Operators without browser automation tools re-run the simulation manually using the same procedure as [Phase 2 — Step 8: Attack Simulation](/csd/api-automation/phase-2-attack/#step-8-attack-simulation):
 
 1. Navigate to `https://xF5XC_DOMAINNAMEx/#/login`
 2. Enter dummy credentials in the Email and Password fields (do not submit)

--- a/docs/trigger-detection.mdx
+++ b/docs/trigger-detection.mdx
@@ -107,6 +107,18 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
    <Screenshot light="/images/devtools-console-output-light.png" dark="/images/devtools-console-output-dark.png" alt="Console output after running the simulation script" />
 </Steps>
 
+### AI-Automated Execution
+
+AI assistants with browser automation tools (MCP Chrome DevTools, Playwright, Puppeteer) execute the simulation programmatically instead of following the manual steps above:
+
+1. **Navigate** — `navigate_page` to the login page URL (e.g., `https://botdemo.sales-demo.f5demos.com/#/login` or your `$F5XC_DOMAINNAME`)
+2. **Snapshot** — `take_snapshot` to identify the email and password form field UIDs
+3. **Fill credentials** — `fill` the email field with `test@example.com` and the password field with `P@ssword123` (do not submit the form)
+4. **Execute script** — `evaluate_script` with the Combined Detection Script IIFE above, wrapped in an arrow function that returns a status object (e.g., `() =&gt; \{ ... return \{ status: 'complete', fields: count \} \}`)
+5. **Capture evidence** — read the `evaluate_script` return value and run `list_console_messages` to capture the full `[CSD Demo]` phased output confirming field harvesting, script injection, and data exfiltration
+
+Operators without browser automation tools use the manual steps above.
+
 <Aside type="tip">
 Detection takes **5-10 minutes** to appear on the CSD dashboard. If alerts are not yet visible after running the script, continue with the [CSD Console walkthrough](/csd/csd-console/) and check back.
 </Aside>


### PR DESCRIPTION
## Summary
- Add AI-Automated Execution subsections to Phase 2 (attack), Phase 3 (mitigate), and Trigger Detection pages with programmatic browser automation sequences (`navigate_page`, `take_snapshot`, `fill`, `evaluate_script`, `list_console_messages`)
- Replace "instruct the human operator" guidance with direct execution for AI assistants that have browser tools
- Preserve all existing manual steps for operators without browser automation

## Test plan
- [ ] Verify MDX renders correctly (no syntax errors in Aside/Steps components)
- [ ] Confirm AI-Automated Execution subsections appear in Phase 2 Step 8, Phase 3 Step 4, and Trigger Detection
- [ ] Confirm manual steps remain intact and unchanged for human operators
- [ ] Run a live demo with Claude Code + MCP Chrome DevTools to verify zero-handoff execution through Phase 2 and Phase 3

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)