### PR TITLE
fix: add --headless flag to chrome-devtools MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "chrome-devtools": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest"],
+      "args": ["-y", "chrome-devtools-mcp@latest", "--headless"],
       "env": {}
     }
   }


### PR DESCRIPTION
## Summary
- Add `--headless` flag to chrome-devtools MCP server args in `.mcp.json`
- Fixes MCP server startup failure in headless/container environments (Codespaces)

## Test plan
- [ ] Restart Claude Code session and verify chrome-devtools MCP tools are available
- [ ] Run `navigate_page` to confirm headless Chrome launches successfully

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)