### PR TITLE
docs: add SALES_ENGINEER.md persona and product expertise file

### DIFF
--- a/SALES_ENGINEER.md
+++ b/SALES_ENGINEER.md
@@ -237,7 +237,7 @@ always tied to a customer concern.
 > right now in the visitor's browser, watching for any JavaScript that tries to touch
 > those payment or login fields. Nothing to install, nothing to configure on the app
 > server. Any questions before we pop open DevTools and actually see that script in action?
-
+>
 > ⏸ *[Pause for audience — ready to continue?]*
 
 **Applies to both demo modes:** walkthrough (as-built reference pages) and API automation


### PR DESCRIPTION
## Summary
- Adds `SALES_ENGINEER.md` defining the F5 CSD Sales Engineer persona for Claude Code
- Includes CSD product expertise, detection signals, PCI DSS alignment, and threat coverage
- Documents demo execution protocol (API automation phases 1-4), platform operations, and content authoring standards

## Test plan
- [ ] Verify file renders correctly on GitHub
- [ ] Confirm CI linting passes (markdownlint, codespell)
- [ ] Review content accuracy against existing `docs/` knowledge base

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)