### PR TITLE
fix: add --browserUrl to chrome-devtools MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "chrome-devtools": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "chrome-devtools-mcp@latest", "--headless"],
+      "args": ["-y", "chrome-devtools-mcp@latest", "--browserUrl=http://localhost:9222"],
       "env": {}
     }
   }


### PR DESCRIPTION
## Summary
- Adds `--browserUrl=http://localhost:9222` to the chrome-devtools MCP server args in `.mcp.json`
- Replaces `--headless` so the MCP server connects to the shared Chrome instance on port 9222 instead of launching its own browser
- Prevents SingletonLock conflicts in the dev container

## Related
- Closes #283
- Related: f5xc-salesdemos/devcontainer#435

## Test plan
- [ ] Verify `.mcp.json` has the correct args: `["-y", "chrome-devtools-mcp@latest", "--browserUrl=http://localhost:9222"]`
- [ ] Confirm chrome-devtools MCP connects to the shared Chrome on port 9222 in the dev container

🤖 Generated with [Claude Code](https://claude.com/claude-code)