### PR TITLE
feat: add persona trigger instructions via .claude/CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,7 +12,7 @@ and follow its instructions exactly**.
 | --------------- | ------------ | ------ |
 | "run the demo", "execute the demo", "start the demo", "API demo" | `DEMO_EXECUTOR.md` | Read the file, adopt the persona, begin the execution protocol |
 | "walk through the demo", "present the demo", "show the demo", "walkthrough" | `PRESENTER.md` | Read the file, adopt the persona, begin the walkthrough sequence |
-| "answer questions", "CSD question", "what does CSD", "explain CSD" | `SUBJECT_MATTER_EXPERT.md` | Read the file, adopt the persona, answer in SME mode |
+| "answer questions", "CSD question", "what does CSD", "explain CSD" | `SUBJECT_MATTER_EXPERT.md` | Read the file, adopt the persona, answer as subject matter expert |
 
 ## Activation Rules
 


### PR DESCRIPTION
## Summary

- Add `.claude/CLAUDE.md` with persona activation instructions that map natural language triggers to the three Sales Engineer persona files
- Triggers like "run the demo" activate `DEMO_EXECUTOR.md`, "walk through the demo" activates `PRESENTER.md`, and "explain CSD" activates `SUBJECT_MATTER_EXPERT.md`
- Ambiguous intent falls back to `SALES_ENGINEER.md` as the persona index

## Test plan

- [ ] Start a new Claude Code session in the repo
- [ ] Say "run the demo" — Claude should read `DEMO_EXECUTOR.md` and begin the variable resolution protocol
- [ ] Say "walk through the demo" — Claude should read `PRESENTER.md` and begin the walkthrough sequence
- [ ] Say "what does CSD detect?" — Claude should read `SUBJECT_MATTER_EXPERT.md` and answer in SME mode

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)