### PR TITLE
fix: set http_redirect to false on HTTPS LB spec

### DIFF
--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -279,7 +279,7 @@ curl -s -X POST \
     "spec": {
       "domains": ["xF5XC_DOMAINNAMEx"],
       "https_auto_cert": {
-        "http_redirect": true,
+        "http_redirect": false,
         "add_hsts": false,
         "port": 443,
         "default_header": {},


### PR DESCRIPTION
## Summary

- Set `http_redirect` from `true` to `false` in the HTTPS LB API spec
- The HTTPS LB should not redirect HTTP traffic since the HTTP LB is the primary entry point in the HTTP-first dual LB architecture (#294)

## Test plan

- [ ] Verify the HTTPS LB spec has `http_redirect: false`
- [ ] Confirm HTTP LB remains the primary entry point with no redirect conflicts

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)