### PR TITLE
fix: correct CSD mitigation behavior claims

### DIFF
--- a/DEMO_EXECUTOR.md
+++ b/DEMO_EXECUTOR.md
@@ -177,13 +177,12 @@ DET-1 and DET-4 may show PENDING on first use — this is normal.
 Apply mitigations, re-run attack, verify via API (Steps 1-5).
 Requires chrome-devtools MCP tools.
 
-> **Critical behavioral note:** CSD mitigation is a **detection and
-> classification layer**, NOT an inline execution blocker. After
-> mitigating a domain, the CSD backend marks it as acknowledged in
-> the dashboard and API. Mitigated domain scripts **still load in
-> the browser** — the observable change is in CSD's risk
-> classification and the mitigated domains list. Do not expect
-> browser-level blocking errors in the re-run simulation.
+> **Critical behavioral note:** CSD mitigation actively **blocks
+> network calls** to mitigated domains. The CSD JavaScript prevents
+> scripts from communicating with domains on the mitigate list,
+> blocking data exfiltration in real time. After re-running the
+> simulation, expect network requests to mitigated domains to be
+> blocked.
 
 **Step 1 — List detected domains:**
 
@@ -221,8 +220,8 @@ individual POST in Step 2 is the authoritative evidence.
 **Step 4 — Re-run attack simulation:**
 
 Execute the same 5-step AI-automated browser sequence as Phase 2.
-Scripts load normally — mitigation is classification-layer, not
-blocking.
+Network calls to mitigated domains are blocked by the CSD JavaScript.
+Script DOM elements may still exist but cannot communicate with blocked domains.
 
 **Step 5 — Verify mitigation effective:**
 
@@ -236,7 +235,7 @@ to confirm mitigation is reflected in detection data.
 | Mitigated domains count | 6 items in list | PASS / FAIL |
 | All Step 2 POSTs | `200` or `409` for each domain | PASS |
 | Attack re-run console | `[CSD Demo] Simulation complete` | PASS / FAIL |
-| CDN scripts in re-run | Load normally (classification-layer) | PASS |
+| Network calls to mitigated domains | Blocked by CSD JavaScript | PASS |
 
 #### Phase 4 — Teardown (`phase-4-teardown.mdx`)
 

--- a/docs/api-automation/phase-3-mitigate.mdx
+++ b/docs/api-automation/phase-3-mitigate.mdx
@@ -10,7 +10,7 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 Phase 3 applies mitigations for the domains detected in Phase 2, then re-runs the attack simulation. Phase 2 must be complete — all DET checks PASS — before proceeding.
 
 <Aside type="note">
-**CSD mitigation is a detection and classification layer, not an inline execution blocker.** After mitigating a domain, the CSD backend marks it as acknowledged in the dashboard and API. Mitigated domain scripts still load in the browser — the observable change is in CSD's risk classification and the mitigated domains list. Do not expect browser-level blocking errors in the re-run simulation.
+**CSD mitigation actively blocks network calls from the browser to mitigated domains.** When a domain is on the mitigate list, the CSD JavaScript prevents scripts on the page from communicating with that domain — blocking data exfiltration in real time. After re-running the simulation, expect network requests to mitigated domains to be blocked.
 </Aside>
 
 <Aside type="caution">
@@ -183,7 +183,7 @@ Operators without browser automation tools re-run the simulation manually using 
 5. Observe console output — mitigated domain scripts should be **blocked by the browser** rather than loading
 
 <Aside type="tip">
-The re-run simulation executes identically to Phase 2 — scripts load, fields are harvested, and exfil fetch calls succeed. CSD mitigation works at the **detection and classification layer**: the backend marks mitigated domains as acknowledged, which changes their status in the dashboard and API. There are no browser-level blocking errors — that is expected and correct behavior.
+After mitigation, the CSD JavaScript blocks network calls to mitigated domains. In the re-run simulation, exfiltration fetch calls to mitigated domains will be blocked. CDN script tags may still be injected into the DOM, but network requests to mitigated domains are prevented.
 </Aside>
 
 ### Evidence
@@ -192,7 +192,7 @@ The re-run simulation executes identically to Phase 2 — scripts load, fields a
 | --- | --- | --- |
 | Login page loaded | `200 OK` at `http://xF5XC_DOMAINNAMEx/#/login` | PASS / FAIL |
 | Console script executed | `[CSD Demo] Simulation complete` in console output | PASS / FAIL |
-| CDN scripts | Load normally (mitigation is classification-layer, not blocking) | PASS |
+| Network calls to mitigated domains | Blocked by CSD JavaScript | PASS |
 
 ## Step 5: Verify Mitigation is Effective
 
@@ -226,7 +226,7 @@ curl -s -X POST \
 | --- | --- | --- |
 | Mitigated domains count | 6 items in list | PASS / FAIL |
 | Attack re-run console | `[CSD Demo] Simulation complete` | PASS / FAIL |
-| CDN scripts in second simulation | Load normally (mitigation is classification-layer) | PASS |
+| Network calls to mitigated domains | Blocked by CSD JavaScript | PASS |
 | CSD mitigated domains API | All 6 domains accepted via POST (200 or 409) | PASS / FAIL |
 
 <Aside type="note">


### PR DESCRIPTION
## Summary
- Corrects 7 locations across `docs/api-automation/phase-3-mitigate.mdx` and `DEMO_EXECUTOR.md` that incorrectly described CSD mitigation as a "detection and classification layer, not an inline execution blocker"
- Replaces with accurate blocking language: CSD mitigation actively blocks network calls from the browser to mitigated domains
- Aligns with existing correct descriptions in `overview.mdx`, `csd-console.mdx`, and `api-automation/index.mdx`, as well as official F5 documentation

## Test plan
- [ ] Verify `grep -rn "classification.layer\|not an inline\|still load in the browser\|not blocking" docs/ DEMO_EXECUTOR.md` returns zero matches
- [ ] Verify blocking language is consistent across all files with `grep -rn "block.*network\|block.*mitigat\|blocked by CSD" docs/ DEMO_EXECUTOR.md`
- [ ] Confirm no contradictions between phase-3-mitigate.mdx, overview.mdx, and csd-console.mdx

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)