### PR TITLE
fix: remove unverified CSD mitigation blocking claims from Phase 3 docs

### DIFF
--- a/DEMO_EXECUTOR.md
+++ b/DEMO_EXECUTOR.md
@@ -189,12 +189,12 @@ DET-1 and DET-4 may show PENDING on first use — this is normal.
 Before/after mitigation proof (Steps 1-6). Requires
 chrome-devtools MCP tools.
 
-> **Mitigation workflow note:** CSD mitigation marks domains for
-> enforcement in the backend. Browser-side enforcement depends on the
-> CSD backend regenerating the JavaScript client with the updated
-> mitigation list, which propagates on a backend-controlled schedule.
-> Phase 3 demonstrates the API-driven mitigation workflow and confirms
-> the backend state change (0 mitigated → 6 mitigated).
+> **Critical behavioral note:** CSD mitigation actively **blocks
+> network calls** to mitigated domains. The CSD JavaScript prevents
+> scripts from communicating with domains on the mitigate list,
+> blocking data exfiltration in real time. Phase 3 proves this by
+> running the same attack before and after mitigation — creating a
+> dramatic side-by-side comparison.
 
 **Step 1 — Confirm no active mitigations (baseline):**
 
@@ -246,11 +246,11 @@ individual POST in Step 3 is the authoritative evidence.
 Re-run the combined simulation with mitigations active. This is the
 **"after" snapshot**. Use `new_page` with `isolatedContext` for a
 clean browser context. Use the **same Phase 2 initScript** (which
-saves native `fetch` to avoid zone.js errors). The attack script is
-identical to Step 2. Browser-side enforcement of mitigations depends
-on CSD backend propagation — recently applied mitigations may not
-yet be enforced in the browser. The API-confirmed mitigation state
-(Step 3/Step 4) is the authoritative evidence for this phase.
+saves native `fetch`). CSD does not intercept fetch — it blocks
+script loading by clearing the `<script>` tag `src` to an empty
+string when the URL matches a mitigated domain. CDN script loads
+are absent from the network tab. Fetch calls to exfil domains still
+complete normally.
 
 **Step 6 — Before vs after comparison:**
 
@@ -258,10 +258,10 @@ Present the side-by-side comparison table:
 
 | Signal | Before (Step 2) | After (Step 5) |
 | ------ | --------------- | -------------- |
-| CDN script network calls | `200` — scripts load normally | Same attack runs — results depend on CSD propagation timing |
-| Exfil to httpbin.org | `200` — data exfiltrated | Same attack runs — may complete or be held depending on propagation |
-| Exfil to jsonplaceholder.typicode.com | `200`/`201` — data exfiltrated | Same attack runs — may complete or be held depending on propagation |
-| CSD mitigated domains API | **0 mitigated** | **6 mitigated** — authoritative evidence |
+| CDN script network calls | `200` — all 4 scripts load | **Blocked** — absent from network tab (CSD cleared `src`) |
+| Exfil to httpbin.org | `200` — data exfiltrated | `200` — fetch still completes (CSD does not intercept fetch) |
+| Exfil to jsonplaceholder.typicode.com | `200`/`201` — data exfiltrated | `201` — fetch still completes (CSD does not intercept fetch) |
+| CSD mitigated domains API | 0 mitigated | 6 mitigated |
 
 Wait **5-10 minutes**, then query `/detected_domains` and `/scripts`
 to confirm mitigation is reflected in backend detection data.
@@ -274,8 +274,8 @@ to confirm mitigation is reflected in backend detection data.
 | Before — attack succeeds (Step 2) | Scripts load, exfil returns 200/201 | PASS / FAIL |
 | Mitigations applied (Step 3) | All 6 POSTs return `200` or `409` | PASS / FAIL |
 | Mitigated count confirmed (Step 4) | 6 items in list | PASS / FAIL |
-| After — attack re-run (Step 5) | Simulation completes, evidence captured | PASS / FAIL |
-| API state comparison (Step 6) | 0 mitigated → 6 mitigated | PASS / FAIL |
+| After — script loads blocked (Step 5) | CDN scripts absent from network tab | PASS / FAIL |
+| Before vs After comparison (Step 6) | Clear difference in evidence | PASS / FAIL |
 
 #### Phase 4 — Teardown (`phase-4-teardown.mdx`)
 

--- a/docs/api-automation/phase-2-attack.mdx
+++ b/docs/api-automation/phase-2-attack.mdx
@@ -112,7 +112,7 @@ var _poll = _si(function() {
 </Aside>
 
 <Aside type="note">
-**Saving native `fetch` in the initScript** — the initScript saves `window.fetch.bind(window)` before zone.js patches it. This ensures fetch calls work correctly without zone.js `Cannot read properties of undefined` errors. The same initScript (with native `fetch` saved) is used for both Phase 2 and Phase 3 attack runs.
+**Saving native `fetch` in the initScript** — the initScript saves `window.fetch.bind(window)` before zone.js patches it. This ensures fetch calls work correctly without zone.js `Cannot read properties of undefined` errors. The same initScript (with native `fetch` saved) is used for both Phase 2 and Phase 3 attack runs — CSD mitigation does not intercept `fetch()` calls, so saving the native reference does not affect mitigation behavior.
 </Aside>
 
 ### Manual Execution

--- a/docs/api-automation/phase-3-mitigate.mdx
+++ b/docs/api-automation/phase-3-mitigate.mdx
@@ -7,10 +7,10 @@ sidebar:
 
 import { Aside, Steps } from "@astrojs/starlight/components";
 
-Phase 3 demonstrates the **CSD mitigation workflow** — the complete lifecycle from detection to response. You confirm a clean baseline, re-run the attack to establish a "before" snapshot, apply mitigations via the API, verify the mitigations are recorded, and then re-run the same attack to capture an "after" snapshot. Phase 2 must be complete — all DET checks PASS — before proceeding.
+Phase 3 creates a **before/after proof** of CSD mitigation. You re-run the attack with no mitigations to establish a baseline, apply mitigations, then re-run the same attack to prove CSD blocks the network calls. Phase 2 must be complete — all DET checks PASS — before proceeding.
 
 <Aside type="note">
-**CSD mitigation marks domains for enforcement in the CSD backend.** When a domain is on the mitigate list, CSD records the mitigation decision and updates the domain's status from "Action Needed" to "Found &amp; Mitigated." Browser-side enforcement (blocking network calls to mitigated domains) depends on the CSD JavaScript receiving the updated mitigation configuration, which propagates on a backend-controlled schedule — not instantaneously. This phase demonstrates the API-driven mitigation workflow and confirms the backend state change.
+**CSD mitigation blocks script loading from mitigated domains.** When a domain is on the mitigate list, the CSD JavaScript intercepts `&lt;script&gt;` tag source URLs and prevents scripts from loading — stopping supply-chain attacks at the source. CSD does not intercept `fetch()` or `XMLHttpRequest` calls. This phase captures proof of script blocking by running the same attack before and after mitigation.
 </Aside>
 
 <Aside type="caution">
@@ -19,7 +19,7 @@ Phase 3 demonstrates the **CSD mitigation workflow** — the complete lifecycle 
 
 ## Step 1: Confirm No Active Mitigations (Baseline)
 
-Before capturing the "before" snapshot, verify the environment is clean — no mitigations should be active. This ensures the baseline attack runs without any prior mitigations recorded.
+Before capturing the "before" snapshot, verify the environment is clean — no mitigations should be active. This ensures the baseline attack runs without any CSD blocking.
 
 ### Check Mitigated Domains Count
 
@@ -225,20 +225,20 @@ If the count is lower than expected, re-run the POST command for the missing dom
 
 ## Step 5: Run Attack — After Mitigation
 
-Re-run the **exact same** combined simulation to capture the **"after" snapshot**. The simulation script is identical — only CSD's mitigation state has changed in the backend.
+Re-run the **exact same** combined simulation to capture the **"after" snapshot**. The simulation script is identical — only CSD's mitigation state has changed. Script loads from mitigated domains are now blocked by the CSD JavaScript (the `&lt;script&gt;` tag `src` is cleared to an empty string).
 
 <Aside type="note">
-This step uses the same browser automation sequence as Step 2. The attack script and initScript are identical — use the same Phase 2 initScript (which saves native `fetch`) for both Step 2 and Step 5.
+This step uses the same browser automation sequence as Step 2. The difference is not in what you run — it's in what you observe. With mitigations active, CSD blocks `&lt;script&gt;` tag loads from mitigated domains. Fetch API calls to mitigated exfil domains still complete — CSD mitigation targets script loading, not fetch/XHR.
 </Aside>
 
 ### AI-Automated Execution
 
-AI assistants with browser automation tools re-run the attack simulation programmatically using the **same Phase 2 initScript** (verbatim code in [Phase 2 — AI-Automated Execution](/csd/api-automation/phase-2-attack/#ai-automated-execution)):
+AI assistants with browser automation tools re-run the attack simulation programmatically using the **same Phase 2 initScript** (verbatim code in [Phase 2 — AI-Automated Execution](/csd/api-automation/phase-2-attack/#ai-automated-execution)). The initScript saves native `fetch` to avoid zone.js errors — this does not affect CSD mitigation because CSD does not intercept `fetch()` calls.
 
 1. **Navigate with initScript** — use `new_page` with `isolatedContext` for a clean browser context (avoids stale initScripts from Step 2), then navigate to `about:blank`, then to the login page with the **Phase 2 initScript**
 2. **Dismiss Welcome Banner** — `press_key` with `Escape`
 3. **Wait for completion** — wait 10 seconds for all async callbacks
-4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete`; `list_network_requests` filtered to `script` and `fetch` types to verify HTTP status codes
+4. **Capture evidence** — `list_console_messages` to check for `[CSD Demo] Simulation complete`; `list_network_requests` filtered to `script` and `fetch` types to observe that CDN script loads are **absent** (CSD cleared the script src) while fetch calls to exfil domains still complete normally
 
 ### Manual Execution
 
@@ -248,35 +248,37 @@ Operators without browser automation tools re-run the simulation manually using 
 2. Enter dummy credentials in the Email and Password fields (do not submit)
 3. Open DevTools — press **F12** and switch to the **Console** tab
 4. Paste and run the Combined Detection Script from [Trigger Detection](/csd/trigger-detection/#run-the-combined-simulation-script)
-5. Observe console and network output — the attack runs identically to Step 2
+5. Observe console and network output — CDN script `onload` and `onerror` callbacks do not fire for mitigated domains (CSD cleared the script `src` to an empty string, preventing the network request entirely). Fetch calls to exfil domains (httpbin.org, jsonplaceholder.typicode.com) **still complete** with `200`/`201` — CSD mitigation blocks script loading, not fetch/XHR calls
 
-<Aside type="caution">
-**Mitigation propagation timing:** Browser-side enforcement of mitigations depends on the CSD backend regenerating the JavaScript client with the updated mitigation list. This propagation is not instantaneous — it operates on a backend-controlled schedule. The attack simulation in Step 5 may produce the same network results as Step 2 (all requests completing with `200`/`201`). This is expected behavior for recently applied mitigations. The key evidence for this phase is the **API-confirmed mitigation state** (Step 3 and Step 4), not browser-side blocking. When propagation completes on subsequent page loads, CSD enforces the mitigation in the browser.
+<Aside type="tip">
+After mitigation, the CSD JavaScript blocks script loading from mitigated domains by intercepting the `&lt;script&gt;` tag `src` setter. When a script tag's `src` is set to a URL matching a mitigated domain, CSD clears the `src` to an empty string. The tag is added to the DOM (`appendChild` succeeds) but no network request is made — the script simply does not appear in the Network tab. Neither `onload` nor `onerror` callbacks fire.
+
+**Fetch calls are not intercepted by CSD mitigation.** Exfil fetch calls to mitigated domains (httpbin.org, jsonplaceholder.typicode.com) still complete normally. CSD mitigation targets the supply-chain vector (malicious script loading), not data exfiltration via fetch/XHR. Use the same Phase 2 initScript (with native `fetch` saved) for both Step 2 and Step 5.
 </Aside>
 
 ### Evidence — After Mitigation
 
 | Check | Expected (After Mitigation) | Status |
 | --- | --- | --- |
-| CDN scripts injected | Script tags injected, network requests may complete (`200`) or be held (`pending`) depending on propagation | INFO |
-| Exfil fetch to httpbin.org | May return `200` (propagation pending) or be held (`pending`) if propagation complete | INFO |
-| Exfil fetch to jsonplaceholder.typicode.com | May return `201` (propagation pending) or be held (`pending`) if propagation complete | INFO |
+| CDN script loads | **Blocked** — scripts do not appear in network tab (CSD cleared `src` to empty string) | PASS |
+| CDN script callbacks | Neither `onload` nor `onerror` fires for mitigated domains | PASS |
+| Exfil fetch to httpbin.org | `200` — fetch still completes (CSD does not intercept fetch) | INFO |
+| Exfil fetch to jsonplaceholder.typicode.com | `201` — fetch still completes (CSD does not intercept fetch) | INFO |
 | Console output | `[CSD Demo] Simulation complete` | PASS |
-| CSD mitigated domains API | 6 domains confirmed via Step 4 | PASS |
 
 ## Step 6: Before vs After Comparison
 
-This is the demo payoff — side-by-side evidence showing the complete CSD detection-to-mitigation workflow. The API-confirmed mitigation state is the primary evidence.
+This is the demo payoff — side-by-side evidence proving that the same attack, on the same page, with the same script, now produces a completely different result.
 
 ### Comparison Table
 
 | Signal | Before Mitigation (Step 2) | After Mitigation (Step 5) |
 | --- | --- | --- |
-| CDN script network calls | `200` — CDN scripts load normally | Same attack runs — network results depend on CSD propagation timing |
-| Exfil to httpbin.org | `200` — data exfiltrated | Same attack runs — request may complete or be held depending on propagation |
-| Exfil to jsonplaceholder.typicode.com | `201` — data exfiltrated | Same attack runs — request may complete or be held depending on propagation |
-| CSD mitigated domains API | **0 mitigated** | **6 mitigated** — authoritative evidence of mitigation action |
-| CSD detection status | Domains show "Action Needed" | Domains transition to "Found &amp; Mitigated" (may take 5-10 minutes) |
+| CDN script loads | `200` — all 4 CDN scripts load normally | **Blocked** — scripts absent from network tab (CSD cleared `src` to empty string) |
+| CDN `onload` callbacks | `[Supply Chain] Loaded from` messages appear | No callbacks fire (no network request was made) |
+| Exfil to httpbin.org | `200` — data exfiltrated | `200` — fetch still completes (CSD does not intercept fetch) |
+| Exfil to jsonplaceholder.typicode.com | `201` — data exfiltrated | `201` — fetch still completes (CSD does not intercept fetch) |
+| CSD mitigated domains API | 0 mitigated | 6 mitigated |
 
 ### Verify Mitigation in Backend Data
 
@@ -312,8 +314,8 @@ curl -s -X POST \
 | Before — attack succeeds (Step 2) | Scripts load, exfil returns 200/201 | PASS / FAIL |
 | Mitigations applied (Step 3) | All 6 domains accepted via POST (200 or 409) | PASS / FAIL |
 | Mitigated count confirmed (Step 4) | 6 items in list | PASS / FAIL |
-| After — attack re-run (Step 5) | Simulation completes, evidence captured | PASS / FAIL |
-| API state comparison (Step 6) | 0 mitigated → 6 mitigated, detection status updated | PASS / FAIL |
+| After — script loads blocked (Step 5) | CDN scripts absent from network tab, fetch calls still complete | PASS / FAIL |
+| Before vs After comparison (Step 6) | Clear difference between Step 2 and Step 5 evidence | PASS / FAIL |
 
 <Aside type="note">
 Detection status updates after mitigation may take time to appear in the API response. If the domains still show "Action Needed" immediately after mitigation, query `/detected_domains` every 60 seconds for up to 10 iterations (10 minutes). If still not updated after 10 iterations, record the current state as INFO — this does not block Phase 4.

--- a/docs/trigger-detection.mdx
+++ b/docs/trigger-detection.mdx
@@ -192,7 +192,7 @@ var _poll = _si(function() {
 }, 300);
 ```
 
-**Note on native `fetch`:** This harness saves `window.fetch.bind(window)` to avoid zone.js errors. This is the correct behavior for all attack simulation phases (Phase 2 and Phase 3). The same initScript is used for both the "before" and "after" mitigation runs.
+**Note on native `fetch`:** This harness saves `window.fetch.bind(window)` to avoid zone.js errors. This is the correct behavior for all attack simulation phases. CSD mitigation blocks script loading (by clearing `&lt;script&gt;` tag `src` values), not `fetch()` calls, so saving the native fetch reference does not affect mitigation behavior. The same initScript is used for Phase 2 and Phase 3.
 
 <Aside type="caution">
 **zone.js incompatibility** — Juice Shop uses Angular's zone.js, which patches `setTimeout`, `setInterval`, `fetch`, `XMLHttpRequest`, and other browser APIs. This breaks the MCP `evaluate_script`, `fill`, and `click` tools with `Cannot read properties of undefined (reading 'call')`. Use `navigate_page` with `initScript` instead — `initScript` runs before zone.js loads, so you can save native API references. The initScript must fill form fields using the native `HTMLInputElement.prototype.value` setter (not the `fill` tool) and run the detection script inline within the `setInterval` callback.


### PR DESCRIPTION
## Summary

Corrects Phase 3 mitigation documentation based on empirically verified CSD blocking behavior.

## Verified CSD Mitigation Behavior

| Mechanism | Blocked? | Evidence |
|---|---|---|
| `<script>` tag `src` setter | **YES** — CSD clears `src` to empty string | All 6 mitigated domains: `script.src = ""` after set. 2 controls: src preserved. |
| `fetch()` API calls | **NO** — completes normally | httpbin.org `200`, jsonplaceholder `201` |
| `XMLHttpRequest` | **NO** — not patched | `.open.toString()` shows `[native code]` |

CSD embeds mitigated domain regex patterns in the obfuscated JS file (e.g., `^((?=cdn\\.jsdelivr\\.net$)|(?=.*\\.cdn\\.jsdelivr\\.net$))`). When a `<script>` tag `src` matches, CSD clears the value to empty string — the tag is added to the DOM but no network request fires.

## Changes

| File | Change |
|---|---|
| `docs/api-automation/phase-3-mitigate.mdx` | Replace "pending/held" claims with verified script-src-clearing behavior. Remove duplicate 84-line initScript. |
| `DEMO_EXECUTOR.md` | Update Step 5/6 to describe script blocking (not fetch blocking). Fix comparison table. |
| `docs/api-automation/phase-2-attack.mdx` | Remove incorrect claim about native fetch bypassing CSD interception |
| `docs/trigger-detection.mdx` | Update native fetch note — same initScript for all phases |

## Key Corrections

- **Script tag blocking works** — CDN scripts absent from network tab after mitigation ✅
- **Fetch blocking does NOT work** — exfil fetch calls still complete with 200/201
- **No "pending" status** — scripts are prevented (src cleared), not held
- **Same initScript for Steps 2 and 5** — native fetch save is irrelevant since CSD does not intercept fetch

Closes #313