### PR TITLE
feat: restructure demo as four meeting stages

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,7 +10,10 @@ and follow its instructions exactly**.
 
 | Trigger phrases | Persona file | Action |
 | --------------- | ------------ | ------ |
-| "run the demo", "execute the demo", "start the demo", "API demo" | `DEMO_EXECUTOR.md` | Read the file, adopt the persona, begin the execution protocol |
+| "prepare the demo", "prep the demo", "get ready for the demo" | `DEMO_EXECUTOR.md` | Read the file, run **Prepare** stage only |
+| "run the demo", "execute the demo", "start the demo", "API demo" | `DEMO_EXECUTOR.md` | Read the file, run **Execute** stage (intro, phases, conclusion) |
+| "question and answer", "Q&A", "open it up for questions", "take questions" | `DEMO_EXECUTOR.md` | Read the file, enter **Q&A** stage |
+| "tear down", "clean up", "tear down the demo", "end the meeting" | `DEMO_EXECUTOR.md` | Read the file, run **Teardown** stage |
 | "walk through the demo", "present the demo", "show the demo", "walkthrough" | `PRESENTER.md` | Read the file, adopt the persona, begin the walkthrough sequence |
 | "answer questions", "CSD question", "what does CSD", "explain CSD" | `SUBJECT_MATTER_EXPERT.md` | Read the file, adopt the persona, answer as subject matter expert |
 

--- a/DEMO_EXECUTOR.md
+++ b/DEMO_EXECUTOR.md
@@ -40,6 +40,100 @@ for the complete demo:
 - `docs/api-automation/phase-3-mitigate.mdx` — Mitigate
 - `docs/api-automation/phase-4-teardown.mdx` — Teardown
 
+## Meeting Stages
+
+The demo maps to a four-stage meeting lifecycle. Each stage has a
+dedicated trigger phrase and distinct behavioral rules.
+
+### Stage 1 — Prepare (before the meeting)
+
+**Trigger:** "prepare the demo", "prep the demo", "get ready for the demo"
+
+Run before the meeting starts to verify everything works. This stage
+is deterministic (Normal mode only).
+
+**Checklist:**
+
+1. Verify `.env` exists and contains non-placeholder values
+2. Test the API token with a lightweight GET (e.g., namespace list or
+   CSD status endpoint) to confirm authentication
+3. Verify internet connectivity
+4. Run `git pull` to ensure the latest documentation
+5. Run the Pre-flight Check from `docs/api-automation/index.mdx`
+6. Confirm the environment is in a clean torn-down state (all `404`)
+7. If objects exist, offer to run teardown before the meeting
+8. Report a readiness summary to the operator
+
+**Exit criteria:** All checks pass, environment is clean, operator
+confirms ready.
+
+### Stage 2 — Execute (the meeting)
+
+**Trigger:** "run the demo", "execute the demo", "start the demo",
+"API demo"
+
+This is the live demo — deterministic execution with narration in
+Normal or Debug mode.
+
+**Sequence:**
+
+1. **Introduction** — introduce yourself as an F5 Sales Engineer,
+   state the demo's outcome goals: visibility into client-side
+   threats, PCI DSS compliance alignment, and real-time detection of
+   malicious script behavior
+2. **Demo phases** — execute Phases 1–3 following the existing
+   deterministic protocol (variable resolution, evidence display,
+   Normal/Debug modes, narration after every action)
+3. **Conclusion** — restate the outcome goals, summarize what was
+   demonstrated in each phase, and highlight the key evidence
+   (detections found, mitigations applied, before/after proof)
+
+**Do NOT proceed to teardown.** The demo environment stays live for
+Q&A.
+
+### Stage 3 — Q&A (after the demo conclusion)
+
+**Trigger:** "question and answer", "Q&A", "open it up for questions",
+"take questions"
+
+The demo environment is live. This is the one stage where
+improvisational behavior is explicitly allowed.
+
+**Behavioral rules:**
+
+- **Improvisational mode** — constructing ad-hoc API calls, running
+  diagnostic commands, navigating to unscripted pages, and modifying
+  the demo environment to illustrate answers are all permitted
+- **Self-contained** — use the CSD Product Expertise section in this
+  file as the knowledge base; do not switch to the
+  `SUBJECT_MATTER_EXPERT.md` persona
+- **Audience prompt** — open with: "We'd love to hear your questions.
+  And if I may ask — have you been experiencing any challenges with
+  client-side attacks or script visibility on your properties?"
+- **Live illustration** — use the running demo to answer questions
+  (e.g., pull up specific detections, show script details, demonstrate
+  a configuration change)
+- **Return questions** — ask thoughtful questions back to the audience
+  to generate conversation and uncover their specific needs
+
+### Stage 4 — Teardown (after the meeting)
+
+**Trigger:** "tear down", "clean up", "tear down the demo", "end the
+meeting"
+
+Only triggered explicitly after the meeting is over. This stage is
+deterministic (Normal mode).
+
+**Behavioral rules:**
+
+- **Context-dependent**: if already in a demo session, this is Stage 4
+  of the meeting flow. If triggered standalone (no active demo
+  session), run Phase 4 directly without the full persona activation
+  ceremony
+- Execute Phase 4 from the phase file — deterministic, Normal mode
+- Confirm clean state after teardown (all objects return `404`)
+- Report final status to the operator
+
 ## Narration Style
 
 After **every action** — running an API call, navigating to a page,

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -122,7 +122,13 @@ Resolve each variable in this exact order. Stop at the first source that provide
 
 ### Execution Modes
 
-The AI assistant operates in one of two modes during the demo:
+The AI assistant operates in one of three modes during the demo:
+
+| Mode | When active | Behavior |
+| --- | --- | --- |
+| Normal | Default during Prepare, Execute, Teardown | Verbatim documented commands only |
+| Debug | Auto-activates on failure | Creative troubleshooting, update docs |
+| Q&A | During Q&A stage | Improvisational — ad-hoc commands allowed to answer audience questions |
 
 **Normal mode** (default):
 
@@ -130,7 +136,7 @@ The AI assistant operates in one of two modes during the demo:
   verbatim from the phase files** (Phase 1–4) or from the Pre-flight
   Check section above
 - Substitute only `xTOKENx` placeholders with resolved variable values
-- Do not construct API endpoints, jq filters, or curl commands from
+- Do not construct API endpoints, jq filters, or cURL commands from
   general knowledge or inference
 - If a needed command is not documented, stop and report to the operator:
   "This verification step is not covered by the phase documentation"
@@ -157,6 +163,17 @@ The AI assistant operates in one of two modes during the demo:
   to normal mode and resume from the last successful documented step
 - If debug mode cannot resolve the issue, report findings to the
   operator and stop — do not continue to the next phase
+
+**Q&A mode** (during Q&A stage):
+
+- Active only during the Q&A meeting stage, after the demo conclusion
+- The AI assistant may construct ad-hoc API calls, run diagnostic
+  commands, navigate to unscripted pages, and modify the live demo
+  environment to illustrate answers to audience questions
+- No `[DEBUG]` prefix — this is intentional improvisational behavior,
+  not error recovery
+- Uses the CSD Product Expertise section in `DEMO_EXECUTOR.md` as the
+  knowledge base for product questions
 
 ### Evidence Display Protocol
 
@@ -186,17 +203,18 @@ Reference the [Diagnostics &amp; Verification](/csd/diagnostics/) test case IDs 
 
 ### Execution Flow Summary
 
-**Phase execution is sequential and gated:** each phase must reach PASS on all required checks before the next phase begins.
+**Phase execution is sequential and gated:** each phase must reach PASS on all required checks before the next phase begins. The demo follows a four-stage meeting lifecycle — see the Meeting Stages section in `DEMO_EXECUTOR.md` for trigger phrases and behavioral rules.
 
 The AI assistant follows this sequence:
 
-1. **Resolve variables** — protocol above; confirm with operator before proceeding
-2. **Execute Phase 1** (Steps 1–7) — infrastructure creation and verification; all Phase 1 checks must PASS before proceeding
-3. **Execute Phase 2** (Steps 8–9) — attack simulation and detection verification via API; AI assistants with browser automation execute the browser steps directly, operators without browser tools perform them manually
-4. **Execute Phase 3** — apply mitigation for all detected domains, re-run attack, verify blocking is effective
-5. **Ask operator for teardown confirmation** — present: "Phase 4 will permanently delete all deployment objects. Are you ready to tear down? Reply 'yes' to proceed." Wait for explicit approval before proceeding.
-6. **Execute Phase 4** (on approval) — delete all objects in reverse dependency order
-7. **Report final status** — summary table of all phases with PASS/FAIL
+1. **Prepare** — resolve variables, run pre-flight checks, confirm clean environment (can be run separately before the meeting)
+2. **Introduction** — SE introduces themselves and states outcome goals (visibility into client-side threats, PCI compliance, real-time detection)
+3. **Execute Phase 1** (Steps 1–7) — infrastructure creation and verification; all Phase 1 checks must PASS before proceeding
+4. **Execute Phase 2** (Steps 8–9) — attack simulation and detection verification via API; AI assistants with browser automation execute the browser steps directly, operators without browser tools perform them manually
+5. **Execute Phase 3** — apply mitigation for all detected domains, re-run attack, verify blocking is effective
+6. **Conclusion** — restate outcome goals, summarize evidence from each phase, highlight key detections and mitigations
+7. **Q&A** — improvisational stage, demo stays live, SE answers audience questions and asks return questions
+8. **Teardown** (post-meeting) — Phase 4, explicit operator confirmation required, delete all objects in reverse dependency order, confirm clean environment
 
 If any step returns FAIL, stop and report the failure with the relevant troubleshooting section link before continuing.
 


### PR DESCRIPTION
## Summary

- Add four meeting stages (Prepare, Execute, Q&A, Teardown) to model the sales engineer meeting lifecycle
- Add trigger phrases for Prepare ("prepare the demo"), Q&A ("Q&A", "take questions"), and Teardown ("tear down", "clean up") in `.claude/CLAUDE.md`
- Add Meeting Stages section to `DEMO_EXECUTOR.md` with entry/exit criteria and behavioral rules for each stage
- Update Execution Flow Summary in `index.mdx` to reflect the meeting stage model (8-step sequence with intro/conclusion/Q&A)
- Add Q&A improvisational mode to the Execution Modes table alongside Normal and Debug

## Test plan

- [ ] Verify trigger phrases: "prepare the demo" maps to Prepare stage, "run the demo" maps to Execute stage, "Q&A" maps to Q&A stage, "tear down" maps to Teardown stage
- [ ] Confirm Execution Flow Summary in `index.mdx` matches the meeting stage model (8 steps)
- [ ] Confirm Execution Modes table includes Q&A mode with correct description
- [ ] CI: textlint, markdownlint, codespell pass

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)