### PR TITLE
feat: make Stage 1 Prepare fully autonomous

### DIFF
--- a/DEMO_EXECUTOR.md
+++ b/DEMO_EXECUTOR.md
@@ -52,20 +52,29 @@ dedicated trigger phrase and distinct behavioral rules.
 Run before the meeting starts to verify everything works. This stage
 is deterministic (Normal mode only).
 
+> **Autonomous execution.** Once triggered, Prepare runs to completion
+> without stopping for confirmation. The operator's trigger phrase
+> ("prepare the demo") is the authorization to clean up, tear down,
+> and verify. The only hard stop is if required environment variables
+> cannot be resolved from `.env` or shell — report what's missing and
+> stop.
+
 **Checklist:**
 
-1. Verify `.env` exists and contains non-placeholder values
+1. Resolve variables (`.env` → shell env → defaults for optional).
+   Only stop if required variables are missing.
 2. Test the API token with a lightweight GET (e.g., namespace list or
    CSD status endpoint) to confirm authentication
 3. Verify internet connectivity
 4. Run `git pull` to ensure the latest documentation
 5. Run the Pre-flight Check from `docs/api-automation/index.mdx`
-6. Confirm the environment is in a clean torn-down state (all `404`)
-7. If objects exist, offer to run teardown before the meeting
+6. If any objects exist, automatically run full Phase 4 teardown — no
+   confirmation needed (Prepare is pre-meeting cleanup)
+7. Re-run pre-flight to confirm all `404` (clean state)
 8. Report a readiness summary to the operator
 
-**Exit criteria:** All checks pass, environment is clean, operator
-confirms ready.
+**Exit criteria:** All checks pass and environment is confirmed clean
+(all pre-flight checks return `404`). No operator confirmation gate.
 
 ### Stage 2 — Execute (the meeting)
 

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -104,6 +104,12 @@ Resolve each variable in this exact order. Stop at the first source that provide
 5. **Apply defaults** — for each missing **optional** variable, use the default from the table below without prompting.
 6. **Display confirmation** — show the final resolved variable table to the operator and wait for approval before executing any API calls.
 
+> **Prepare stage override:** During Stage 1 Prepare, skip the wait in
+> step 6. Display the resolved variable table for the record, then
+> proceed immediately. Steps 1–5 still apply — if any required variable
+> is missing after checking `.env` and shell, stop and report the
+> missing variables.
+
 ### Required vs Optional Variables
 
 | Variable | Required | Default | Placeholder (treat as missing) |

--- a/docs/api-automation/phase-4-teardown.mdx
+++ b/docs/api-automation/phase-4-teardown.mdx
@@ -11,6 +11,8 @@ Phase 4 removes all objects created during the exercise in reverse dependency or
 
 <Aside type="caution">
 **Confirm before proceeding.** If you are an AI assistant, you MUST ask the human operator: "Phase 4 will permanently delete all deployment objects. Are you ready to tear down? Reply 'yes' to proceed." Do not execute any DELETE commands until the operator confirms.
+
+**Exception:** When teardown runs as part of Stage 1 Prepare (pre-meeting cleanup), the operator's "prepare the demo" trigger phrase serves as implicit authorization. No additional confirmation is needed. The confirmation gate above applies only during standalone teardown or post-meeting Stage 4.
 </Aside>
 
 ## Teardown Order


### PR DESCRIPTION
## Summary

- Rewrites the Stage 1 Prepare checklist in `DEMO_EXECUTOR.md` to run autonomously — auto-teardown, no approval gates, no "operator confirms ready" exit criteria
- Adds a Prepare stage override to the Variable Resolution Protocol in `index.mdx` so the variable table is displayed but not waited on
- Adds a Prepare exception to the Phase 4 teardown confirmation gate in `phase-4-teardown.mdx` so teardown runs without prompting during pre-meeting cleanup

Closes #323

## Test plan

- [ ] Read `DEMO_EXECUTOR.md` Stage 1 and confirm zero user-prompting steps (except missing required vars)
- [ ] Read `index.mdx` variable resolution and confirm the Prepare override is present after step 6
- [ ] Read `phase-4-teardown.mdx` and confirm the Prepare exception is inside the caution aside
- [ ] Mentally trace "prepare the demo" flow — no decision points should require operator input when variables are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)