### PR TITLE
docs: audit and correct CSD documentation accuracy against F5 official sources

### DIFF
--- a/.claude/agents/demo-researcher.md
+++ b/.claude/agents/demo-researcher.md
@@ -102,6 +102,26 @@ find, verify, and report answers with citations — nothing else.
 | ID | URL | Topics |
 | -- | --- | ------ |
 | PCI-BLOG | <https://www.f5.com/company/blog/pci-dss-v4-0-browser-based-attacks> | PCI DSS v4.0, browser attacks, 6.4.3, 11.6.1 |
+| F5-PCI-BLOG | <https://www.f5.com/company/blog/distributed-cloud-client-side-defense-prepares-customers-for-pci-dss> | PCI DSS v4.0.1 CSD compliance mapping |
+| PCI-SSC-LIBRARY | <https://www.pcisecuritystandards.org/document_library/> | PCI DSS v4.0 standard documents |
+
+### Threat Research & Standards
+
+| ID | URL | Topics |
+| -- | --- | ------ |
+| OWASP-CLICKJACKING | <https://owasp.org/www-community/attacks/Clickjacking> | Clickjacking, UI redressing, iframe overlay |
+| OWASP-CLICKJACKING-DEFENSE | <https://cheatsheetseries.owasp.org/cheatsheets/Clickjacking_Defense_Cheat_Sheet.html> | Clickjacking prevention, CSP frame-ancestors |
+| OWASP-MITB | <https://owasp.org/www-community/attacks/Man-in-the-browser_attack> | Man-in-the-Browser, browser trojan, session hijack |
+| OWASP-XSS | <https://owasp.org/www-community/attacks/xss/> | Cross-site scripting, script injection, DOM XSS |
+| OWASP-CLIENT-SIDE-TOP10 | <https://owasp.org/www-project-top-10-client-side-security-risks/> | Client-side security risks ranking |
+| MITRE-SUPPLY-CHAIN | <https://attack.mitre.org/techniques/T1195/> | Supply chain compromise T1195 |
+| MITRE-SUPPLY-CHAIN-SW | <https://attack.mitre.org/techniques/T1195/002/> | Software supply chain compromise T1195.002 |
+| MITRE-MITB | <https://attack.mitre.org/techniques/T1185/> | Man-in-the-Browser T1185 |
+| MITRE-EXFILTRATION | <https://attack.mitre.org/tactics/TA0010/> | Data exfiltration tactic TA0010 |
+| MITRE-RESOURCE-HIJACK | <https://attack.mitre.org/techniques/T1496/> | Resource hijacking T1496, cryptojacking |
+| AKAMAI-WEB-SKIMMING | <https://www.akamai.com/glossary/what-is-web-skimming> | Web skimming, digital skimming definition |
+| SANSEC-MAGECART | <https://sansec.io/what-is-magecart> | Magecart, formjacking, e-commerce skimming |
+| F5-CSD-PRIVACY | <https://www.f5.com/company/policies/f5-distributed-cloud-client-side-defense-privacy-statement> | CSD data collection, privacy, what telemetry contains |
 
 ## Research Protocol
 
@@ -192,6 +212,12 @@ Common question patterns and recommended source priority:
 | "How do I configure X?" | LOCAL-XC-CONFIG | F5-CSD-HOWTO |
 | "What does the dashboard show?" | LOCAL-CSD-CONSOLE | F5-CSD-ABOUT |
 | "How does telemetry work?" | LOCAL-TELEMETRY | F5-CSD-ABOUT |
+| "What is clickjacking?" | OWASP-CLICKJACKING | LOCAL-OVERVIEW |
+| "What is man-in-the-browser?" | OWASP-MITB, MITRE-MITB | LOCAL-OVERVIEW |
+| "What is a supply chain attack?" | MITRE-SUPPLY-CHAIN | F5-ATTACK-VECTORS |
+| "What is cryptojacking?" | MITRE-RESOURCE-HIJACK | LOCAL-OVERVIEW |
+| "What is web skimming/Magecart?" | SANSEC-MAGECART, AKAMAI-WEB-SKIMMING | F5-ATTACK-VECTORS |
+| "What data does CSD collect?" | F5-CSD-PRIVACY | LOCAL-TELEMETRY |
 
 ## Execution Rules
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import { Aside } from "@astrojs/starlight/components";
 
-F5 Distributed Cloud Client-Side Defense (CSD) protects web applications from client-side attacks by monitoring JavaScript behavior directly in the browser. The F5 XC load balancer injects a telemetry script into every page served to the client. This script observes all JavaScript activity — which scripts load, which form fields they read, and which network connections they make. Telemetry data is sent to the F5 XC platform where machine learning models analyze script behavior, assign risk scores, and flag anomalies. Security teams review detections in the CSD console and take action by allowing or mitigating script domains.
+F5 Distributed Cloud Client-Side Defense (CSD) protects web applications from client-side attacks by monitoring JavaScript behavior directly in the browser. The F5 XC load balancer can be configured to inject the CSD telemetry script into pages served to the client. This script observes all JavaScript activity — which scripts load, which form fields they read, and which network connections they make. Telemetry data is sent to the F5 XC platform where machine learning models analyze script behavior, assign risk scores, and flag anomalies. Security teams review detections in the CSD console and take action by allowing or mitigating script domains.
 
 ```mermaid
 flowchart LR
@@ -40,7 +40,7 @@ CSD tracks **script-load source domains** in the Network view — not fetch/XHR 
 | **Behavior timeline** | Charts script risk level, source domain, and type over time | Script detail &rarr; Overview &rarr; Behaviors Over Time |
 | **Affected user attribution** | Tracks impacted users by IP, geolocation, browser, and device | Script detail &rarr; Affected Users tab |
 | **Domain allow list** | Mark trusted script domains as allowed | Dashboard &rarr; domain row &rarr; Add To Allow List |
-| **Domain mitigate list** | Block scripts from specific domains on next page load | Dashboard &rarr; domain row &rarr; Add To Mitigate List |
+| **Domain mitigate list** | Block network calls and form field reads from specific script domains, preventing data exfiltration | Dashboard &rarr; domain row &rarr; Add To Mitigate List |
 | **Alert configuration** | Notifications for new domains, risk changes, suspicious behavior | Notifications section |
 | **Script justification** | Add notes explaining why a script is authorized (PCI DSS compliance) | Script detail &rarr; Justification field |
 | **Transaction tracking** | Monthly telemetry event counter confirming CSD is active | Dashboard &rarr; Transactions Consumed card |
@@ -52,11 +52,18 @@ Understanding what CSD does **not** monitor is critical for setting accurate dem
 
 | Limitation | Detail |
 | --- | --- |
-| **Dynamically created fields** | CSD only tracks `input` fields present in the DOM at page load. Fields injected by JavaScript after load are not monitored. |
 | **Fetch/XHR destinations** | The Network view shows script-load source domains only. Domains contacted via `fetch()`, `XMLHttpRequest`, or image beacons do not appear. |
-| **Code-level patterns** | CSD does not flag `eval()`, `Function()`, or other obfuscation techniques as separate detection signals. |
-| **Dashboard counters** | Summary cards (Action Needed, Found &amp; Mitigated, etc.) only increment after an admin actions a domain. New detections appear in the Script List first. |
-| **First-party script domains** | The Dashboard domain table tracks third-party script domains only. High-risk first-party scripts appear in the Script List but not on the Dashboard. |
+
+<Aside type="note" title="Observed behaviors during demo testing">
+The following behaviors were observed during demo testing and may change as CSD evolves. These are not official F5 product specifications.
+
+| Observed Behavior | Detail |
+| --- | --- |
+| **Dynamically created fields** | In our testing, CSD tracks `input` fields present in the DOM at page load. Fields injected by JavaScript after load were not observed to be monitored. |
+| **Code-level obfuscation** | In our testing, CSD does not appear to flag dynamic code execution techniques or obfuscation patterns as separate detection signals. |
+| **Dashboard counters** | In our testing, summary cards (Action Needed, Found &amp; Mitigated, etc.) only increment after an admin actions a domain. New detections appear in the Script List first. |
+| **First-party script domains** | In our testing, the Dashboard domain table tracks third-party script domains only. High-risk first-party scripts appear in the Script List but not on the Dashboard. |
+</Aside>
 
 ## PCI DSS v4.0 Mapping
 
@@ -73,20 +80,20 @@ Use the **Script justification** feature to document why each script is authoriz
 
 ## Threat Coverage Matrix
 
-The following table maps common client-side attack categories to the CSD detection signals that would fire during each attack type:
+The following table maps common client-side attack categories to the CSD detection signals that would fire during each attack type. Attack types marked with **\*** are confirmed by [F5 official documentation](https://www.f5.com/cloud/products/client-side-defense). Unmarked types are inferred based on CSD's detection signal categories and may not be explicitly claimed by F5.
 
 | Attack Category | Description | Field Reads | Script Injection | Network |
 | --- | --- | --- | --- | --- |
-| **Formjacking** | Malicious script reads form field values and exfiltrates them | Yes | — | Yes |
-| **Digital skimming** | Injects overlay forms or scripts to capture payment data | Yes | Yes | Yes |
-| **Supply chain attack** | Compromised third-party library loads malicious code | — | Yes | Yes |
+| **Formjacking** \* | Malicious script reads form field values and exfiltrates them | Yes | — | Yes |
+| **Digital skimming** \* | Injects overlay forms or scripts to capture payment data | Yes | Yes | Yes |
+| **Supply chain attack** \* | Compromised third-party library loads malicious code | — | Yes | Yes |
+| **Data exfiltration** \* | Reads sensitive data and sends it to external domains | Yes | — | Yes |
+| **Script injection** \* | Inserts unauthorized `<script>` tags into the page | — | Yes | Yes |
+| **Cryptojacking** \* | Injects cryptocurrency mining scripts | — | Yes | Yes |
 | **DOM manipulation** | Injects or modifies page elements to deceive users | — | Yes | — |
-| **Data exfiltration** | Reads sensitive data and sends it to external domains | Yes | — | Yes |
-| **Script injection** | Inserts unauthorized `<script>` tags into the page | — | Yes | Yes |
-| **Man-in-the-Browser** | Intercepts form data within the browser session | Yes | — | Yes |
-| **Cryptojacking** | Injects cryptocurrency mining scripts | — | Yes | Yes |
-| **Clickjacking** | Overlays invisible frames to hijack user clicks | — | Yes | — |
-| **Web skimmer persistence** | Re-injects skimmer scripts across page navigations | — | Yes | Yes |
+| **Man-in-the-Browser** | Intercepts form data within the browser session — see [OWASP](https://owasp.org/www-community/attacks/Man-in-the-browser_attack) and [MITRE T1185](https://attack.mitre.org/techniques/T1185/) | Yes | — | Yes |
+| **Clickjacking** | Overlays invisible frames to hijack user clicks — see [OWASP](https://owasp.org/www-community/attacks/Clickjacking) | — | Yes | — |
+| **Web skimmer persistence** | Re-injects skimmer scripts across page navigations — see [Sansec Magecart Research](https://sansec.io/what-is-magecart) | — | Yes | Yes |
 
 <Aside type="note">
 "Network" detection depends on whether the attack loads scripts from external domains. Exfiltration via `fetch()` or image beacons to external domains is **not** visible in the CSD Network view — only script-load source domains are tracked.

--- a/docs/references.mdx
+++ b/docs/references.mdx
@@ -31,6 +31,23 @@ sidebar:
 - **British Airways breach (2018)** — Magecart Group 6 injected a skimmer into the BA payment page, compromising 380,000 transactions
 - **Ticketmaster breach (2018)** — Supply chain attack via compromised Inbenta chatbot script that skimmed payment card data
 
+## Attack Categories &amp; Standards
+
+- [OWASP Clickjacking](https://owasp.org/www-community/attacks/Clickjacking) — UI redressing attack definition and prevention
+- [OWASP Man-in-the-Browser](https://owasp.org/www-community/attacks/Man-in-the-browser_attack) — Browser-based interception attack
+- [OWASP Cross-Site Scripting](https://owasp.org/www-community/attacks/xss/) — Script injection attack taxonomy
+- [MITRE ATT&amp;CK T1195 Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/) — Supply chain attack framework
+- [MITRE ATT&amp;CK T1185 Man-in-the-Browser](https://attack.mitre.org/techniques/T1185/) — Browser manipulation technique
+- [MITRE ATT&amp;CK T1496 Resource Hijacking](https://attack.mitre.org/techniques/T1496/) — Cryptojacking classification
+- [MITRE ATT&amp;CK TA0010 Exfiltration](https://attack.mitre.org/tactics/TA0010/) — Data exfiltration tactic
+- [Akamai Web Skimming](https://www.akamai.com/glossary/what-is-web-skimming) — Digital skimming overview
+- [Sansec Magecart Research](https://sansec.io/what-is-magecart) — Magecart groups and campaigns
+
+## Privacy &amp; Compliance
+
+- [F5 CSD Privacy Statement](https://www.f5.com/company/policies/f5-distributed-cloud-client-side-defense-privacy-statement) — What CSD telemetry collects
+- [F5 CSD PCI DSS v4.0.1 Blog](https://www.f5.com/company/blog/distributed-cloud-client-side-defense-prepares-customers-for-pci-dss) — Official PCI compliance mapping
+
 ## Industry Standards
 
 - [OWASP Top 10 Client-Side Security Risks](https://owasp.org/www-project-top-10-client-side-security-risks/) — Top client-side security risks project

--- a/docs/telemetry-beacons.mdx
+++ b/docs/telemetry-beacons.mdx
@@ -8,11 +8,11 @@ sidebar:
 import { Aside, Steps } from "@astrojs/starlight/components";
 import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
 
-CSD telemetry operates in two phases. First, the `common.js` scripts load from the application origin via standard **GET** requests — these are the instrumentation layer that injects CSD's monitoring code into the page. Once initialized, the scripts periodically send telemetry back to F5 via **POST** requests known as **beacons**. These beacons are sent to F5-operated signal collection domains (`*.zeronaught.com`), not to the application origin.
+CSD telemetry operates in two phases. First, instrumentation scripts load from the application origin via standard **GET** requests — these inject CSD's monitoring code into the page. The script URL pattern follows the format `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, though the exact path varies by deployment. Once initialized, the scripts periodically send telemetry back to F5 via **POST** requests known as **beacons**. These beacons are sent to F5-operated signal collection domains (`*.zeronaught.com`), not to the application origin.
 
 | Property | Value |
 | --- | --- |
-| Script loads | `GET /common.js?single`, `GET /common.js?async`, `GET /common.js?async&seed=...` on the application origin |
+| Script loads | CSD instrumentation scripts loaded via `GET` requests on the application origin — filter for `__imp_apg__` or `zeronaught` in DevTools to identify them |
 | Beacon destinations | `POST` to F5 signal collection infrastructure (e.g., `us.gimp.zeronaught.com`, `csd.zeronaught.com`) |
 | Payload format | Encoded binary — not human-readable JSON |
 | Frequency | Periodic during page lifetime; additional beacons fire on specific events (form field access, new script load) |
@@ -25,7 +25,7 @@ CSD beacons carry **script behavior metadata**, not user input:
 - **Form field access events** — which scripts read or interacted with which input fields (field names and types)
 - **Page metadata** — current URL, timestamps, page lifecycle events
 
-Beacons do **not** send the values users type into form fields. Field names and input types are reported so the platform can detect unauthorized access patterns, but the actual data (passwords, card numbers, personal information) stays in the browser.
+CSD is designed to report script behavior metadata — field names, input types, and access patterns — rather than user-entered form data. The [F5 CSD Privacy Statement](https://www.f5.com/company/policies/f5-distributed-cloud-client-side-defense-privacy-statement) describes CSD as collecting "information about which assets are accessing various page elements or data structures," focusing on script behavior rather than user input content.
 
 ## Observe beacons in DevTools
 

--- a/docs/xc-configuration.mdx
+++ b/docs/xc-configuration.mdx
@@ -62,14 +62,14 @@ The CSD Configuration page (above) registers a domain with the reporting engine.
 1. Open the [demo application](https://botdemo.sales-demo.f5demos.com) in Chrome
 2. Press **F12** to open DevTools
 3. Go to the **Elements** tab
-4. Search for `common.js` in the HTML
-5. Confirm `<script src="/common.js?single">` is present in the `<head>`
-6. Confirm a second script `<script src="/common.js?async&seed=...">` was dynamically loaded
+4. Search for `__imp_apg__` or `zeronaught` in the HTML to locate CSD instrumentation scripts
+5. Confirm one or more CSD `<script>` tags are present in the `<head>` — the exact script paths vary by deployment
+6. Confirm the scripts were injected by the load balancer (they are not part of the application source)
 </Steps>
 
 <Screenshot light="/images/csd-injected-scripts-light.png" dark="/images/csd-injected-scripts-dark.png" alt="Injected scripts in DevTools Elements tab" />
 
-Both `common.js` scripts are injected by the F5 XC load balancer — they are not part of the application source.
+The CSD instrumentation scripts are injected by the F5 XC load balancer — they are not part of the application source.
 
 <Aside type="caution">
 If the scripts are not present, verify the domain is configured and you are accessing the application through the F5 XC load balancer (not directly to the origin).


### PR DESCRIPTION
## Summary

- Replaces unverifiable `common.js` filename with accurate CSD script URL pattern description (`__imp_apg__` / `zeronaught` filter)
- Corrects mitigation mechanism description: blocks exfiltration network calls, not script loading
- Adds F5-confirmed (★) vs inferred distinction to Threat Coverage Matrix with citations for inferred types
- Softens absolute privacy claim to cite [F5 CSD Privacy Statement](https://www.f5.com/company/policies/f5-distributed-cloud-client-side-defense-privacy-statement) with qualified language
- Separates verified Detection Boundaries from observed demo behaviors (moved to an Aside)
- Fixes injection scope: "can be configured to inject" replaces "injects into every page"
- Adds Attack Categories & Standards and Privacy & Compliance sections to `references.mdx`
- Adds 15 threat research sources and 6 question-routing rules to `demo-researcher.md`

Closes #329

## Test plan

- [ ] Verify no `common.js` references remain in `docs/` (confirmed by grep)
- [ ] Confirm all new URLs are accessible (spot-checked: OWASP Clickjacking, MITRE T1185, Sansec Magecart — all confirmed)
- [ ] Review overview.mdx: Threat Coverage Matrix asterisk notation renders correctly in MDX
- [ ] Review overview.mdx: Aside with nested table renders correctly
- [ ] Docs build CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)