### PR TITLE
docs: fix demo-run documentation gaps from 2026-03-20 session

### DIFF
--- a/.claude/agents/demo-researcher.md
+++ b/.claude/agents/demo-researcher.md
@@ -53,6 +53,7 @@ find, verify, and report answers with citations — nothing else.
 | LOCAL-PHASE2 | `docs/api-automation/phase-2-attack.mdx` | Phase 2 attack simulation |
 | LOCAL-PHASE3 | `docs/api-automation/phase-3-mitigate.mdx` | Phase 3 mitigation, allow/mitigate |
 | LOCAL-PHASE4 | `docs/api-automation/phase-4-teardown.mdx` | Phase 4 teardown, cleanup |
+| LOCAL-FAQ | `docs/faq.mdx` | Frequently asked questions — alerts, logging, SIEM, mitigation behavior, detection timing |
 
 ### F5 API Documentation
 

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -102,6 +102,12 @@ Resolve each variable in this exact order. Stop at the first source that provide
 3. **Identify missing values** — compare resolved values against the required/optional table below. A value is "missing" if it is absent, empty, or still set to a placeholder default (e.g., `example-api-token`, `example-tenant`, `example-namespace`, `app.example.com`, `user@example.com`).
 4. **Prompt the human operator** — for each missing **required** variable, ask the operator to provide the value. Do not proceed until all required variables are resolved.
 5. **Apply defaults** — for each missing **optional** variable, use the default from the table below without prompting.
+
+> **Empty string = missing:** A variable exported with an empty value
+> (e.g., `F5XC_HC_NAME=""`) is treated the same as an unset variable —
+> apply the default. Use shell parameter expansion
+> (`${F5XC_HC_NAME:-csd-hc}`) to apply defaults in one step.
+
 6. **Display confirmation** — show the final resolved variable table to the operator and wait for approval before executing any API calls.
 
 > **Prepare stage override:** During Stage 1 Prepare, skip the wait in
@@ -251,9 +257,9 @@ F5XC_NAMESPACE=example-namespace
 F5XC_ROOT_DOMAIN=example.com
 
 # Optional — Juice Shop demo defaults are used when not set
-# F5XC_HC_NAME=example-healthcheck
+# F5XC_HC_NAME=csd-hc
 # F5XC_ORIGIN_IP=44.232.69.192
-# F5XC_ORIGIN_POOL=juice-origin
+# F5XC_ORIGIN_POOL=csd-origin
 # F5XC_ORIGIN_PORT=3000
 ```
 
@@ -290,10 +296,10 @@ Each `xTOKENx` placeholder in the curl commands maps directly to an environment 
 | `xF5XC_LB_NAMEx` | `example-lb` | HTTP Load Balancer base name (creates `${name}-http` and `${name}-https`) |
 | `xF5XC_DOMAINNAMEx` | `app.example.com` | FQDN to protect |
 | `xF5XC_ROOT_DOMAINx` | `example.com` | Root domain (eTLD+1) for CSD protected domain |
-| `xF5XC_ORIGIN_POOLx` | `juice-origin` | Origin pool name |
+| `xF5XC_ORIGIN_POOLx` | `csd-origin` | Origin pool name |
 | `xF5XC_ORIGIN_IPx` | `44.232.69.192` | Origin server IP |
 | `xF5XC_ORIGIN_PORTx` | `3000` | Origin server port |
-| `xF5XC_HC_NAMEx` | `example-healthcheck` | Healthcheck name |
+| `xF5XC_HC_NAMEx` | `csd-hc` | Healthcheck name |
 
 <Aside type="tip">
 **Tenant is automatic**: The tenant identifier is derived from your API URL (e.g., `f5-amer-ent` from `https://f5-amer-ent.console.ves.volterra.io`). You do not need to supply it — the platform populates tenant references automatically when creating objects.
@@ -341,10 +347,10 @@ Values are resolved using the deterministic protocol defined in [AI Assistant Ex
 | `xF5XC_LB_NAMEx` | HTTP Load Balancer base name (creates `${name}-http` and `${name}-https`) | `example-lb` |
 | `xF5XC_DOMAINNAMEx` | FQDN to protect | `app.example.com` |
 | `xF5XC_ROOT_DOMAINx` | Root domain (eTLD+1) | `example.com` |
-| `xF5XC_ORIGIN_POOLx` | Origin pool name | `juice-origin` |
+| `xF5XC_ORIGIN_POOLx` | Origin pool name | `csd-origin` |
 | `xF5XC_ORIGIN_IPx` | Origin server IP | `44.232.69.192` |
 | `xF5XC_ORIGIN_PORTx` | Origin server port | `3000` |
-| `xF5XC_HC_NAMEx` | Healthcheck name | `example-healthcheck` |
+| `xF5XC_HC_NAMEx` | Healthcheck name | `csd-hc` |
 
 ### oneOf Choice Groups
 

--- a/docs/api-automation/phase-2-attack.mdx
+++ b/docs/api-automation/phase-2-attack.mdx
@@ -130,8 +130,17 @@ Operators without browser automation tools perform the steps manually:
 | Signal | Behavior | Detection |
 | --- | --- | --- |
 | Form field harvesting | Reads email and password input values | Scripts reading sensitive form fields — flagged High Risk |
-| Script injection | Injects 4 `&lt;script&gt;` tags from `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, `ga.jspm.io` | 4 new third-party script domains detected |
+| Script injection | Injects 4 `&lt;script&gt;` tags from `cdn.jsdelivr.net`, `esm.sh`, `unpkg.com`, `ga.jspm.io` | Up to 4 new third-party script domains detected (CDN availability varies) |
 | Data exfiltration | Sends harvested data via `fetch` to `www.httpbin.org` and `jsonplaceholder.typicode.com` | Network calls to external domains |
+
+<Aside type="note">
+**CDN availability varies.** Not all 4 CDN scripts will load in every
+run — browser resource limits, network conditions, or CDN throttling
+may cause some to fail with `ERR_INSUFFICIENT_RESOURCES` or timeout.
+The simulation succeeds if **any** CDN script loads. CSD detects the
+injection attempt regardless of whether the script loads successfully —
+the `&lt;script&gt;` tag creation itself is the detection signal.
+</Aside>
 
 <Aside type="tip">
 After running the attack simulation, use this deterministic polling loop to wait for detections:
@@ -153,7 +162,7 @@ The AI assistant should report the following. For AI-automated execution, eviden
 | Login page loaded | `200 OK` at `http://$F5XC_DOMAINNAME/#/login` | PASS / FAIL |
 | Console script executed | `[CSD Demo] Simulation complete` in console output | PASS / FAIL |
 | Fields harvested | Count &gt; 0 in console output | PASS |
-| Scripts injected | 4 CDN domains in console output | PASS |
+| Scripts injected | 1–4 CDN domains in console output (some may fail with resource errors) | PASS if any CDN domain appears |
 | Exfil channels | 2 fetch POST attempts in console output | PASS |
 
 <Aside type="tip">
@@ -210,13 +219,24 @@ START=$(( NOW - 86400 ))
 curl -s \
   -H "Authorization: APIToken xF5XC_API_TOKENx" \
   "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/formFields?startTime=$START&endTime=$NOW" \
-  | jq '{fields: [.form_fields[]? | {field_name: .fieldName, field_type: .fieldType, page_url: .pageUrl}]}'
+  | jq '{total: .total_size, fields: [.form_fields[]? | {name: .name, sensitivity: .analysis.value, scripts: (.associated_scripts | length), locations: .locations}]}'
 ```
 
 | Field | Expected | Status |
 | --- | --- | --- |
-| Form fields detected | Email and password fields from login page | PASS if fields appear |
-| `field_type` | `email`, `password` | PASS if sensitive field types detected |
+| `total` | &gt; 0 | PASS if &gt; 0; PENDING if 0 but DET-3 passes |
+| `name` | Includes `email`, `password` | PASS if sensitive fields appear |
+| `sensitivity` | `Sensitive` for email/password fields | PASS if ML classified correctly |
+
+<Aside type="note">
+**Form field processing is slower than domain detection.** The
+`/formFields` endpoint may return fields with partial metadata
+on first query. The ML sensitivity classification (`Sensitive` vs
+`Not Sensitive`) populates after backend processing completes —
+this can take 20–30 minutes after the first simulation run. If
+fields show but lack classification, requery later. DET-3
+(`/detected_domains`) is the primary pass criteria.
+</Aside>
 
 ### Phase 2 Evidence Summary
 

--- a/docs/api-automation/phase-3-mitigate.mdx
+++ b/docs/api-automation/phase-3-mitigate.mdx
@@ -266,6 +266,16 @@ The CSD JavaScript is expected to block script loading from mitigated domains by
 | Exfil fetch to jsonplaceholder.typicode.com | `201` — fetch still completes (CSD does not intercept fetch) | INFO |
 | Console output | `[CSD Demo] Simulation complete` | PASS |
 
+<Aside type="tip">
+**Backend verification is the most reliable proof.** If browser-visible
+script blocking is not observed within the demo timeframe, use the
+`/detected_domains` API response as primary evidence. The
+`mitigatedDomains` count and reduced `actionNeededCount` in the domain
+summary confirm that mitigations are active in the backend — even if
+the CSD JavaScript in the browser hasn't yet refreshed its
+configuration to enforce blocking.
+</Aside>
+
 ## Step 6: Before vs After Comparison
 
 This is the demo payoff — side-by-side evidence proving that the same attack, on the same page, with the same script, now produces a completely different result.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,0 +1,81 @@
+---
+title: FAQ
+sidebar:
+  order: 12
+  label: FAQ
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Frequently asked questions about F5 Distributed Cloud Client-Side Defense, compiled from demo sessions and customer conversations.
+
+## Does CSD generate alerts when violations are detected?
+
+Yes, but CSD-specific alert rules must be explicitly configured. CSD auto-creates an Alert Receiver using the account email address provided during setup. You can configure alert triggers for:
+
+- New suspicious domain detected
+- Risk score threshold exceeded
+- New script detected on a protected page
+- Behavior change on a previously seen script
+
+Alerts can be scoped per-domain or applied globally across all protected domains. See the [CSD Console — Alert Configuration](/csd/csd-console/#alert-configuration) section for setup details.
+
+<Aside type="note">
+Alert rules are configured in the CSD dashboard, not via the automation API. The API endpoints (`/scripts`, `/detected_domains`) provide detection data but do not trigger alerts on their own.
+</Aside>
+
+## Can I view HTTP request logs for CSD events?
+
+CSD operates via **client-side JavaScript telemetry** — there are no server-side HTTP logs for script detections or mitigation enforcement. The detection pipeline works as follows:
+
+1. The CSD JavaScript tag (injected by the load balancer) runs in the visitor's browser
+2. It monitors script loading, DOM mutations, and form field access
+3. Telemetry beacons are sent to the F5 backend for analysis
+4. Detection results appear in the CSD API and dashboard
+
+The **load balancer access logs** (`/api/data/namespaces/\{ns\}/access_logs`) include a `csd_js_injection` field that confirms whether the CSD script tag was injected into a response. For CSD detection data, use the API endpoints: [`/scripts`](/csd/api-reference/#detected-scripts), [`/detected_domains`](/csd/api-reference/#detected-domains), and [`/formFields`](/csd/api-reference/#form-fields).
+
+See the [Diagnostics](/csd/diagnostics/) guide for the full Layer 7 (HTTP) and Layer 8 (CSD telemetry) verification tests.
+
+## Does CSD integrate with SIEM tools (Splunk, Datadog, etc.)?
+
+No native SIEM webhook or syslog integration is documented for CSD specifically. The CSD detection data is available through the REST API endpoints:
+
+- `/scripts` — detected scripts with risk levels
+- `/detected_domains` — categorized domains (CDN, exfil, etc.)
+- `/formFields` — form fields accessed by scripts with sensitivity classification
+
+Customers can poll these API endpoints on a schedule and forward detection data to their SIEM. See the [API Reference](/csd/api-reference/) for endpoint details and authentication.
+
+<Aside type="tip">
+The F5 Distributed Cloud platform supports **Global Log Receiver** configurations for streaming HTTP access logs to external systems (Splunk, Datadog, S3, etc.). While this covers load balancer access logs (including the `csd_js_injection` field), it does not include CSD detection events. For detection data, use the API polling approach described above.
+</Aside>
+
+## What does CSD mitigation actually block?
+
+CSD mitigation blocks `<script>` tag loading from mitigated domains by intercepting the `src` attribute — the CSD JavaScript clears the `src` to an empty string, preventing the network request entirely. This targets the **supply-chain vector**: malicious third-party scripts that are injected into the page via `<script>` tags.
+
+CSD mitigation does **not** intercept:
+
+- `fetch()` calls
+- `XMLHttpRequest` calls
+- `<img>` or `<link>` tag loads
+- WebSocket connections
+
+This design is intentional — CSD focuses on the script loading mechanism that supply-chain attacks (Magecart, formjacking, skimming) use to inject malicious code. Application-level API calls made via `fetch()` or `XMLHttpRequest` are outside CSD's scope and are handled by other F5 XC security features (WAF, Bot Defense, API Protection).
+
+See [Phase 3 — Mitigate](/csd/api-automation/phase-3-mitigate/) for a before/after proof demonstrating script blocking behavior.
+
+## How long do detections take to appear after running an attack?
+
+Detection timing varies by endpoint:
+
+| Endpoint | Typical timing | Notes |
+| --- | --- | --- |
+| `/detected_domains` | Minutes | Populates first — this is the primary indicator that the CSD pipeline is processing |
+| `/scripts` | 10–30 minutes | Uses a slower backend processing schedule |
+| `/formFields` | 20–30 minutes | ML sensitivity classification (`Sensitive` vs `Not Sensitive`) requires additional processing |
+
+Detections **persist across infrastructure teardown/rebuild** when the same protected domain is re-registered on the same tenant. After a teardown and rebuild, query `/detected_domains` once — if the response contains items, prior detections are still available and no waiting is required.
+
+See the [Phase 2 — Detection Verification](/csd/api-automation/phase-2-attack/#step-9-detection-verification-via-api) section for the recommended polling protocol.

--- a/docs/placeholders.json
+++ b/docs/placeholders.json
@@ -51,7 +51,7 @@
     },
     "F5XC_ORIGIN_POOL": {
       "type": "text",
-      "default": "juice-origin",
+      "default": "csd-origin",
       "description": "Origin pool name"
     },
     "F5XC_ORIGIN_IP": {
@@ -66,7 +66,7 @@
     },
     "F5XC_HC_NAME": {
       "type": "text",
-      "default": "example-healthcheck",
+      "default": "csd-hc",
       "description": "Healthcheck name"
     }
   }


### PR DESCRIPTION
## Summary

Closes #335

- Fix placeholder token defaults (`juice-origin` → `csd-origin`, `example-healthcheck` → `csd-hc`) across index.mdx and placeholders.json
- Clarify that empty env vars are treated as missing in the variable resolution protocol
- Document CDN script load variability in Phase 2 evidence tables and add explanatory Aside
- Fix form fields jq filter to match actual API response structure (`.name`, `.analysis.value`, `.locations`)
- Add backend verification tip to Phase 3 for demo timeframe edge cases
- Create new FAQ page (`docs/faq.mdx`) with 5 Q&A entries from demo session observations
- Add FAQ to demo-researcher agent source index

## Test plan

- [ ] Grep confirms no remaining `juice-origin` or `example-healthcheck` in docs
- [ ] FAQ page renders at `/csd/faq/` with sidebar order 12
- [ ] Updated jq filter produces structured output against live API
- [ ] All modified MDX files pass linter checks
- [ ] Phase 2 and Phase 3 evidence tables are internally consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)