### PR TITLE
Add RFC 5737 TEST-NET skip logic to T3 Origin Health checks

### DIFF
--- a/READINESS_MATRIX.md
+++ b/READINESS_MATRIX.md
@@ -70,6 +70,15 @@ FAIL in any T2 check blocks execution.
 
 WARN only — does not block execution.
 
+**Skip condition:** If `F5XC_ORIGIN_IP` falls within an RFC 5737
+TEST-NET range (`192.0.2.0/24`, `198.51.100.0/24`, or
+`203.0.113.0/24`), skip the entire T3 tier. Record both PF-T3-1 and
+PF-T3-2 as **SKIP** with note: "Origin IP is an RFC 5737 TEST-NET
+documentation address — not routable, connectivity testing skipped."
+These ranges are reserved for use in documentation and examples per
+[RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737) and will
+never respond to connectivity tests.
+
 11. **PF-T3-1: Origin Connectivity** — cURL the origin IP:port with
     `--connect-timeout 10`. Record HTTP status. `000` is WARN.
 12. **PF-T3-2: HTML Content** — only if T3-1 returned a valid HTTP

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -293,6 +293,22 @@ dig +short NS xF5XC_ROOT_DOMAINx
 
 These checks verify the backend application is reachable.
 
+<Aside type="tip" title="RFC 5737 TEST-NET Addresses">
+The IP ranges `192.0.2.0/24` (TEST-NET-1), `198.51.100.0/24`
+(TEST-NET-2), and `203.0.113.0/24` (TEST-NET-3) are reserved by
+[RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737) for use in
+documentation and examples. They are **not routable** on the public
+internet and will never respond to connectivity tests. When
+`F5XC_ORIGIN_IP` is set to an address in one of these ranges, it is
+an intentional documentation placeholder — not a misconfiguration.
+</Aside>
+
+**Skip condition:** If `F5XC_ORIGIN_IP` is within a TEST-NET range
+(`192.0.2.0/24`, `198.51.100.0/24`, or `203.0.113.0/24`), skip the
+entire T3 tier. Record both PF-T3-1 and PF-T3-2 as **SKIP** with
+note: "Origin IP is an RFC 5737 TEST-NET documentation address —
+not routable, connectivity testing skipped."
+
 #### PF-T3-1: Origin Server Connectivity
 
 ```bash
@@ -325,7 +341,13 @@ curl -s --max-time 10 "http://xF5XC_ORIGIN_IPx:xF5XC_ORIGIN_PORTx/" \
 
 ### T4: Environment Clean
 
-These are the existing pre-flight checks — verify no leftover objects from a prior demo run.
+These checks verify no **named F5 XC configuration objects** remain
+from a prior demo run — HTTP load balancers, HTTPS load balancers,
+origin pools, healthchecks, protected domains, and mitigated domains.
+T4 is about object-level cleanup: whether API objects that would
+conflict with Phase 1 creation still exist. It does not test IP
+addresses, network connectivity, or origin health (those concerns
+belong to T3).
 
 Run the six pre-flight commands from the [Pre-flight Check](#pre-flight-check) section above. Apply the [Decision Logic](#decision-logic) to determine next steps. If objects exist, auto-teardown is performed during Prepare stage (no confirmation needed).
 
@@ -391,8 +413,8 @@ After running all tiers, present a consolidated readiness report:
 ### T3: Origin Health
 | Check | Result | Status |
 |---|---|---|
-| PF-T3-1: Origin Connectivity | 200 | PASS |
-| PF-T3-2: HTML Content | HTML detected | PASS |
+| PF-T3-1: Origin Connectivity | TEST-NET address (192.0.2.1) | SKIP |
+| PF-T3-2: HTML Content | TEST-NET address | SKIP |
 
 ### T4: Environment Clean
 | Check | Result | Status |


### PR DESCRIPTION
## Summary

- Add skip condition to T3 Origin Health tier when `F5XC_ORIGIN_IP` is an RFC 5737 TEST-NET address (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`)
- Document what TEST-NET addresses are and why they're used as placeholders
- Clarify T4 tier purpose as named F5 XC configuration object cleanup (not network validation)

## Test plan

- [ ] Verify docs build: `docker run` dev preview renders `docs/api-automation/index.mdx` correctly
- [ ] Run Prepare stage pre-flight with `.env` containing `F5XC_ORIGIN_IP=192.0.2.1` — T3 should report SKIP
- [ ] Run Prepare stage with a real IP — T3 should run normally

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)