### PR TITLE
feat: extend T1 quota probes and T2-3 DNS auto-remediation

### DIFF
--- a/READINESS_MATRIX.md
+++ b/READINESS_MATRIX.md
@@ -40,7 +40,10 @@ FAIL in any T0 check blocks all subsequent tiers.
 
 ### T1: Quotas & Capacity
 
-WARN only — does not block execution.
+Mixed blocking — PF-T1-1 is WARN (healthchecks are optional for
+CSD). PF-T1-4 through PF-T1-6 are FAIL if quota is exhausted
+(origin pools, load balancers, and protected domains are required
+for the demo to proceed).
 
 4. **PF-T1-1: Healthcheck Quota** — POST a probe healthcheck named
    `preflight-quota-probe`, then DELETE it. If creation returns
@@ -49,21 +52,45 @@ WARN only — does not block execution.
 5. **PF-T1-2: Origin Pool Count** — GET origin pools list, record
    count.
 6. **PF-T1-3: HTTP LB Count** — GET LB list, record count.
+7. **PF-T1-4: Origin Pool & Endpoint Quota** — POST a probe origin
+   pool named `preflight-origin-probe` with one endpoint (RFC 5737
+   TEST-NET IP `192.0.2.1`), then DELETE it. If creation returns
+   error code `8` (exhausted limits for origin pools or endpoints),
+   record as FAIL — origin pools are required for the demo. This
+   single probe tests both origin pool and endpoint sub-object
+   quota simultaneously.
+8. **PF-T1-5: HTTP Load Balancer Quota** — POST a probe HTTP LB
+   named `preflight-lb-probe` with `default_route_pools: []` and
+   `dns_volterra_managed: false`, then DELETE it. If creation
+   returns error code `8`, record as FAIL — load balancers are
+   required. One probe covers both HTTP and HTTPS LBs (same API
+   object kind `http_loadbalancers`).
+9. **PF-T1-6: Protected Domain Quota** — POST a probe protected
+   domain named `preflight-probe.example.com` with
+   `protected_domain: "example.com"` (RFC 2606), then DELETE it.
+   If creation returns error code `8`, record as FAIL. A `409`
+   (domain already exists) counts as PASS — it proves the API
+   accepts domain registrations and quota is not exhausted.
 
 ### T2: Platform Prerequisites
 
 FAIL in any T2 check blocks execution.
 
-7. **PF-T2-1: CSD Tenant Status** — GET CSD status, check
-   `isConfigured` and `isEnabled`. If either is `false`, report
-   FAIL and stop.
-8. **PF-T2-2: DNS Zone Exists** — GET
-   `/api/config/dns/namespaces/system/dns_zones/{root_domain}`.
-   Record status code. `404` is WARN (external DNS may be in use).
-   `403` is WARN (token may lack system namespace access).
-9. **PF-T2-3: DNS Managed Records** — only if T2-2 returned `200`,
-   check `allow_http_lb_managed_records`. Record `true`/`false`.
-10. **PF-T2-4: DNS Nameserver Authority** — run
+10. **PF-T2-1: CSD Tenant Status** — GET CSD status, check
+    `isConfigured` and `isEnabled`. If either is `false`, report
+    FAIL and stop.
+11. **PF-T2-2: DNS Zone Exists** — GET
+    `/api/config/dns/namespaces/system/dns_zones/{root_domain}`.
+    Record status code. `404` is WARN (external DNS may be in use).
+    `403` is WARN (token may lack system namespace access).
+12. **PF-T2-3: DNS Managed Records** — only if T2-2 returned `200`,
+    check `allow_http_lb_managed_records`. If `true`, record PASS.
+    If `false` or `null` and F5 XC is the authoritative DNS provider
+    (PF-T2-4 shows `f5clouddns.com` nameservers), auto-enable using
+    GET+PUT on the DNS zone, then re-check to confirm. If external
+    DNS, record as INFO (managed records are not applicable). If
+    auto-remediation fails (PUT returns error), record as FAIL.
+13. **PF-T2-4: DNS Nameserver Authority** — run
     `dig +short NS {root_domain}`. Record whether F5 XC or external.
 
 ### T3: Origin Health
@@ -79,27 +106,31 @@ These ranges are reserved for use in documentation and examples per
 [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737) and will
 never respond to connectivity tests.
 
-11. **PF-T3-1: Origin Connectivity** — cURL the origin IP:port with
+14. **PF-T3-1: Origin Connectivity** — cURL the origin IP:port with
     `--connect-timeout 10`. Record HTTP status. `000` is WARN.
-12. **PF-T3-2: HTML Content** — only if T3-1 returned a valid HTTP
+15. **PF-T3-2: HTML Content** — only if T3-1 returned a valid HTTP
     status, check if response contains `</html>`. Record result.
 
 ### T4: Environment Clean
 
 Executes auto-teardown if leftover objects are found.
 
-13. Run the six pre-flight commands (HTTP LB, HTTPS LB, Origin Pool,
+16. Run the six pre-flight commands (HTTP LB, HTTPS LB, Origin Pool,
     Healthcheck, protected domains, mitigated domains). Record each
     HTTP status code.
-14. Also check for stale `preflight-quota-probe` healthcheck from a
-    prior interrupted run — delete if found.
-15. **Auto-teardown if needed** — if any objects exist (HTTP `200` on
+17. Also check for stale probe objects from a prior interrupted
+    pre-flight run — delete if found:
+    - `preflight-quota-probe` (healthcheck)
+    - `preflight-lb-probe` (HTTP load balancer)
+    - `preflight-origin-probe` (origin pool)
+    - `preflight-probe.example.com` (protected domain)
+18. **Auto-teardown if needed** — if any objects exist (HTTP `200` on
     infrastructure checks, or non-zero real counts on
     protected/mitigated domains), run the full Phase 4 teardown by
     reading and executing commands from
     `docs/api-automation/phase-4-teardown.mdx`. No confirmation
     needed — Prepare is pre-meeting cleanup.
-16. **Re-run pre-flight** — execute the same pre-flight checks to
+19. **Re-run pre-flight** — execute the same pre-flight checks to
     confirm all objects return `404` and counts are 0. If any object
     still exists, report failure and stop.
 
@@ -107,13 +138,13 @@ Executes auto-teardown if leftover objects are found.
 
 INFO only.
 
-17. **PF-T5-1: Recent Certificate Issuance History** — there is no
+20. **PF-T5-1: Recent Certificate Issuance History** — there is no
     API to query Let's Encrypt rate limits directly. Note as INFO
     that frequent create/destroy cycles can exhaust the weekly limit
     (5 duplicate certificates per week per domain). If this demo
     domain has been torn down and rebuilt multiple times recently,
     include a warning that HTTPS may be rate-limited.
-18. **PF-T5-2: Cert State** — only if an HTTPS LB existed in T4
+21. **PF-T5-2: Cert State** — only if an HTTPS LB existed in T4
     (before teardown), note the `cert_state` value observed. If
     `AutoCertDomainRateLimited`, include a warning that HTTPS may
     not be available and the demo should plan for HTTP-only.

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -153,7 +153,7 @@ curl -s -o /dev/null -w '%\{http_code\}' \
 
 ### T1: Quotas &amp; Capacity
 
-These checks verify the tenant has room to create the objects Phase 1 needs.
+These checks verify the tenant has room to create the objects Phase 1 needs. PF-T1-1 is WARN because healthchecks are optional for CSD. PF-T1-4 through PF-T1-6 are **FAIL** because origin pools, load balancers, and protected domains are required — if any of these hit quota limits, the demo cannot proceed.
 
 #### PF-T1-1: Healthcheck Quota
 
@@ -228,6 +228,158 @@ curl -s \
 | Count returned | **PASS** (informational) | Note the current count — the demo creates 2 LBs |
 | API error | **FAIL** | Permissions issue — see PF-T0-2 |
 
+#### PF-T1-4: Origin Pool &amp; Endpoint Quota
+
+Create and immediately delete a probe origin pool to test whether the tenant has capacity for both origin pool and endpoint objects. The origin pool requires at least one origin server entry, which creates an endpoint sub-object — this single probe tests both quotas simultaneously.
+
+```bash
+# Create probe
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metadata": {
+      "name": "preflight-origin-probe",
+      "namespace": "xF5XC_NAMESPACEx"
+    },
+    "spec": {
+      "origin_servers": [{
+        "public_ip": { "ip": "192.0.2.1" },
+        "labels": {}
+      }],
+      "no_tls": {},
+      "port": 80,
+      "same_as_endpoint_port": {},
+      "healthcheck": [],
+      "loadbalancer_algorithm": "LB_OVERRIDE",
+      "endpoint_selection": "LOCAL_PREFERRED"
+    }
+  }' \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/origin_pools" \
+  | jq '{name: .metadata.name, code: .code, message: .message}'
+
+# Cleanup probe
+curl -s -X DELETE \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/origin_pools/preflight-origin-probe" \
+  > /dev/null
+```
+
+| Result | Status | Remediation |
+| --- | --- | --- |
+| Probe created (name returned, no error code) | **PASS** | Origin pool and endpoint quota available |
+| `"code": 8` with "endpoint has exhausted limits" | **FAIL** | Endpoint quota full — origin pools are required for the demo and cannot be created. Delete unused origin pools in other namespaces to free endpoint capacity, or contact your administrator to increase the tenant limit. |
+| `"code": 8` with "origin_pool has exhausted limits" | **FAIL** | Origin pool quota full — delete unused origin pools or contact your administrator. |
+
+<Aside type="note">
+The probe uses RFC 5737 TEST-NET IP `192.0.2.1` as the origin server — this is a documentation-only address that will not generate real traffic. The origin pool API requires at least one origin server entry (`origin_servers` minimum is 1), so this probe inherently tests both origin pool and endpoint sub-object quota in a single API call.
+</Aside>
+
+#### PF-T1-5: HTTP Load Balancer Quota
+
+Create and immediately delete a probe HTTP load balancer to test whether the tenant has capacity. This probe uses `default_route_pools: []` (no origin pool dependency) and `dns_volterra_managed: false` (no DNS record creation). One probe covers both HTTP and HTTPS LBs since they share the same API object kind (`http_loadbalancers`).
+
+```bash
+# Create probe
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metadata": {
+      "name": "preflight-lb-probe",
+      "namespace": "xF5XC_NAMESPACEx",
+      "disable": false
+    },
+    "spec": {
+      "domains": ["preflight-probe.example.com"],
+      "http": {
+        "dns_volterra_managed": false,
+        "port": 80
+      },
+      "advertise_on_public_default_vip": {},
+      "default_route_pools": [],
+      "disable_rate_limit": {},
+      "no_service_policies": {},
+      "round_robin": {},
+      "disable_waf": {},
+      "no_challenge": {},
+      "disable_bot_defense": {},
+      "disable_api_definition": {},
+      "disable_api_discovery": {},
+      "disable_ip_reputation": {},
+      "disable_malicious_user_detection": {},
+      "single_lb_app": {
+        "disable_discovery": {},
+        "disable_ddos_detection": {},
+        "disable_malicious_user_detection": {}
+      },
+      "disable_trust_client_ip_headers": {},
+      "user_id_client_ip": {},
+      "disable_threat_mesh": {},
+      "l7_ddos_action_default": {},
+      "system_default_timeouts": {},
+      "default_sensitive_data_policy": {},
+      "disable_malware_protection": {},
+      "disable_api_testing": {}
+    }
+  }' \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers" \
+  | jq '{name: .metadata.name, code: .code, message: .message}'
+
+# Cleanup probe
+curl -s -X DELETE \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/preflight-lb-probe" \
+  > /dev/null
+```
+
+| Result | Status | Remediation |
+| --- | --- | --- |
+| Probe created (name returned, no error code) | **PASS** | HTTP load balancer quota available |
+| `"code": 8` with "exhausted limits" | **FAIL** | Load balancer quota full — LBs are required for the demo. Delete unused load balancers or contact your administrator. |
+
+<Aside type="note">
+The probe uses `dns_volterra_managed: false` to prevent DNS record creation and `default_route_pools: []` to avoid requiring an origin pool. The domain `preflight-probe.example.com` uses the RFC 2606 reserved `example.com` to avoid conflicts with real domains.
+</Aside>
+
+#### PF-T1-6: Protected Domain Quota
+
+Create and immediately delete a probe protected domain to test whether the tenant has capacity for CSD domain registrations.
+
+```bash
+# Create probe
+curl -s -X POST \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metadata": {
+      "name": "preflight-probe.example.com",
+      "namespace": "xF5XC_NAMESPACEx"
+    },
+    "spec": {
+      "protected_domain": "example.com"
+    }
+  }' \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains" \
+  | jq '{name: .metadata.name, code: .code, message: .message}'
+
+# Cleanup probe
+curl -s -X DELETE \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains/preflight-probe.example.com" \
+  > /dev/null
+```
+
+| Result | Status | Remediation |
+| --- | --- | --- |
+| Probe created (name returned, no error code) | **PASS** | Protected domain quota available |
+| `409` (domain already exists) | **PASS** | `example.com` is already registered on the tenant — this proves the API accepts domain registrations and quota is not exhausted |
+| `"code": 8` with "exhausted limits" | **FAIL** | Protected domain quota full — delete unused protected domains or contact your administrator. |
+
+<Aside type="note">
+The probe uses RFC 2606 reserved domain `example.com`. A `409` response is a valid PASS condition — it means the domain is already registered on the tenant, which proves the API is functional and quota is not exhausted. The DELETE may return `404` if the `409` occurred (the probe object was never created), which is expected.
+</Aside>
+
 ### T2: Platform Prerequisites
 
 These checks verify tenant-level services that the demo depends on.
@@ -263,7 +415,9 @@ curl -s -o /dev/null -w '%\{http_code\}' \
 
 #### PF-T2-3: DNS Managed Records Enabled
 
-Only run if PF-T2-2 returned `200` (F5 XC DNS zone exists):
+Only run if PF-T2-2 returned `200` (F5 XC DNS zone exists).
+
+**Check current state:**
 
 ```bash
 curl -s \
@@ -272,10 +426,44 @@ curl -s \
   | jq '.spec.primary.allow_http_lb_managed_records'
 ```
 
-| Result | Status | Remediation |
-| --- | --- | --- |
-| `true` | **PASS** | LB-managed DNS records will be auto-created |
-| `false` or `null` | **WARN** | Managed records disabled — Phase 1 Step 4 will need to enable them, or DNS records must be created manually. See [Phase 1 Step 4, Option A](/csd/api-automation/phase-1-build/#option-a-f5-xc-managed-dns). |
+**Auto-remediate if needed:** If the result is `false` or `null` AND PF-T2-4 shows F5 XC nameservers (`ns1.f5clouddns.com`, `ns2.f5clouddns.com`), auto-enable managed records using GET+PUT:
+
+```bash
+# Get current zone config
+ZONE_CONFIG=$(curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/dns/namespaces/system/dns_zones/xF5XC_ROOT_DOMAINx")
+
+# Update with managed records enabled
+echo "$ZONE_CONFIG" \
+  | jq '.spec.primary.allow_http_lb_managed_records = true' \
+  | curl -s -X PUT \
+    -H "Authorization: APIToken xF5XC_API_TOKENx" \
+    -H "Content-Type: application/json" \
+    -d @- \
+    "xF5XC_API_URLx/api/config/dns/namespaces/system/dns_zones/xF5XC_ROOT_DOMAINx" \
+  | jq .
+```
+
+Then re-check to confirm the update took effect:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/dns/namespaces/system/dns_zones/xF5XC_ROOT_DOMAINx" \
+  | jq '.spec.primary.allow_http_lb_managed_records'
+```
+
+<Aside type="caution">
+The zone spec contains an `x-ves-io-managed` rr_set_group with platform-managed records. The `PUT` payload **must preserve this group** — omitting it causes HTTP 403 "reserved for internal purposes". Always retrieve the current zone configuration with `GET` first, modify only the `allow_http_lb_managed_records` field, and send back the complete spec.
+</Aside>
+
+| Result | DNS Authority | Status | Remediation |
+| --- | --- | --- | --- |
+| `true` | Any | **PASS** | LB-managed DNS records will be auto-created |
+| `false`/`null` | F5 XC | **Auto-remediate** | Enable via GET+PUT, verify, report result |
+| `false`/`null` | External | **INFO** | Managed records not applicable for external DNS — Phase 1 Step 4 will use [Option B](/csd/api-automation/phase-1-build/#option-b-external-dns-provider) (manual record creation) |
+| Auto-remediation failed | F5 XC | **FAIL** | Token may lack system namespace write access — contact tenant administrator |
 
 #### PF-T2-4: DNS Nameserver Authority
 
@@ -351,6 +539,29 @@ belong to T3).
 
 Run the six pre-flight commands from the [Pre-flight Check](#pre-flight-check) section above. Apply the [Decision Logic](#decision-logic) to determine next steps. If objects exist, auto-teardown is performed during Prepare stage (no confirmation needed).
 
+Also check for and delete stale probe objects from prior interrupted pre-flight runs:
+
+```bash
+# Stale probe cleanup (delete in any order — probes have no dependencies)
+curl -s -X DELETE -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/healthchecks/preflight-quota-probe" \
+  > /dev/null
+
+curl -s -X DELETE -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/preflight-lb-probe" \
+  > /dev/null
+
+curl -s -X DELETE -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/origin_pools/preflight-origin-probe" \
+  > /dev/null
+
+curl -s -X DELETE -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/protected_domains/preflight-probe.example.com" \
+  > /dev/null
+```
+
+Each DELETE returns `200` (empty `{}`) if the object existed, or `404` if it did not — both are expected.
+
 ### T5: Certificate Readiness
 
 These checks assess whether HTTPS will work or the demo should plan for HTTP-only.
@@ -401,6 +612,9 @@ After running all tiers, present a consolidated readiness report:
 | PF-T1-1: Healthcheck Quota | Probe created | PASS |
 | PF-T1-2: Origin Pool Count | 14 | PASS |
 | PF-T1-3: HTTP LB Count | 1 | PASS |
+| PF-T1-4: Origin Pool & Endpoint Quota | Probe created | PASS |
+| PF-T1-5: HTTP LB Quota | Probe created | PASS |
+| PF-T1-6: Protected Domain Quota | Probe created | PASS |
 
 ### T2: Platform Prerequisites
 | Check | Result | Status |
@@ -760,7 +974,12 @@ The `single_lb_app` object has its own required `oneOf` groups. Setting `single_
 - **404 Not Found** — namespace or object name is incorrect. List objects with `GET /api/config/namespaces/\{namespace\}/\{object_type\}`.
 - **409 Conflict** — object already exists. For protected domains, a `409` with "domain already exists (in uriList)" means the root domain is already registered on the tenant — this is a success condition, not an error. For other objects, delete first or use `PUT` to update.
 - **422 Unprocessable Entity** — JSON schema validation failed. Common causes: missing `oneOf` choice, multiple choices set in same group, wrong field type. Check the error message for the specific field.
-- **Object limit exhausted** (error code `8`, message `"Object kind healthcheck has exhausted limits"`) — tenant has hit an object limit (e.g., 150 healthchecks). The API returns HTTP 200 with a JSON error body, not HTTP 429. For healthchecks, this is non-blocking — skip Phase 1 Step 1 and create the origin pool without a healthcheck reference. CSD does not depend on health monitoring. For other object types, delete unused objects or contact your administrator to increase limits.
+- **Object limit exhausted** (error code `8`, message `"Object kind {kind} has exhausted limits({N})"`) — tenant has hit an object quota limit. The API returns HTTP 200 with a JSON error body containing `"code": 8`, not HTTP 429. Behavior depends on the object type:
+  - **Healthcheck** (limit ~150): **Non-blocking** — skip Phase 1 Step 1 and create the origin pool without a healthcheck reference. CSD does not depend on health monitoring.
+  - **Endpoint** (limit ~500): **Blocking** — endpoints are sub-objects created inside origin pools. If this limit is hit, origin pool creation fails. Delete unused origin pools (which frees their endpoint sub-objects) or contact your administrator to increase the tenant limit.
+  - **Origin pool**: **Blocking** — delete unused origin pools or contact your administrator.
+  - **HTTP load balancer**: **Blocking** — delete unused load balancers or contact your administrator.
+  - **Protected domain**: **Blocking** — delete unused protected domains or contact your administrator.
 
 ## Troubleshooting
 

--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -146,6 +146,10 @@ curl -s -X POST \
 
 A `200` response confirms the origin pool was created.
 
+<Aside type="caution">
+If the response contains `"code": 8` with a message like `"Object kind endpoint has exhausted limits(500)"` or `"Object kind origin_pool has exhausted limits"`, the tenant has hit its quota. Unlike healthchecks, origin pools are **required** for the demo — the demo cannot proceed without one. Delete unused origin pools from other namespaces to free capacity (deleting an origin pool also frees its endpoint sub-objects), then retry. If the limit cannot be resolved, contact your F5 XC administrator to increase the tenant quota.
+</Aside>
+
 ### Verify Healthcheck is Linked
 
 If you included a healthcheck reference, confirm it is properly linked:
@@ -259,6 +263,10 @@ curl -s -X POST \
 
 A `200` response confirms the HTTP load balancer was created with CSD enabled.
 
+<Aside type="caution">
+If the response contains `"code": 8` with a message like `"Object kind http_loadbalancer has exhausted limits"`, the tenant has hit its load balancer quota. Load balancers are **required** for the demo. Delete unused load balancers to free capacity, then retry.
+</Aside>
+
 ### HTTPS Load Balancer (Secondary)
 
 This is the **secondary** load balancer. It uses `https_auto_cert` on port 443 with automatic Let's Encrypt certificate provisioning. This LB is optional for demo progression — if the certificate hits rate limits (`AutoCertDomainRateLimited`), the demo continues using the HTTP LB.
@@ -332,6 +340,10 @@ curl -s -X POST \
 ```
 
 A `200` response confirms the HTTPS load balancer was created.
+
+<Aside type="caution">
+If the response contains `"code": 8` with "exhausted limits", the HTTPS LB cannot be created. The HTTPS LB is optional — the demo proceeds using the HTTP LB. Note the quota limitation in the Phase 1 Evidence Summary as INFO.
+</Aside>
 
 ### Evidence
 
@@ -575,6 +587,7 @@ curl -s -X POST \
 | --- | --- | --- |
 | `200` | Domain registered successfully | Continue to Step 7 |
 | `409` (domain already exists) | Domain was previously registered on this tenant | Already done — continue to Step 7 |
+| `"code": 8` (exhausted limits) | Protected domain quota full | **Blocking** — protected domains are required for CSD. Delete unused protected domains or contact your administrator. |
 
 ### Evidence
 


### PR DESCRIPTION
## Summary
- Add probe-then-delete quota checks for origin pool/endpoint (PF-T1-4), HTTP LB (PF-T1-5), and protected domain (PF-T1-6) — all FAIL if quota exhausted
- Upgrade PF-T2-3 DNS managed records from WARN to auto-remediate when F5 XC is authoritative DNS
- Add error code 8 handling to Phase 1 Steps 2, 3, and 6
- Expand T4 stale probe cleanup for all new probe objects
- All probe specs validated against live F5 XC API

## Motivation

During a live demo, origin pool creation failed with `"Object kind endpoint has exhausted limits(500)"`. The readiness matrix only probed healthcheck quota — this was a false READY that should have been NOT READY.

## Test plan
- [x] PF-T1-4 probe correctly returns FAIL (endpoint quota at 500 on current tenant)
- [x] PF-T1-5 probe correctly creates/deletes LB with empty route pools
- [x] PF-T1-6 probe correctly creates/deletes protected domain
- [x] PF-T2-3 shows PASS with `allow_http_lb_managed_records: true`
- [x] T4 stale probe cleanup covers all new probe objects
- [x] Overall readiness status correctly shows NOT READY due to PF-T1-4 FAIL
- [ ] Verify super-linter passes

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)