### PR TITLE
docs: expand F5 XC acronym on first use in four files

### DIFF
--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -147,7 +147,7 @@ curl -s -X POST \
 A `200` response confirms the origin pool was created.
 
 <Aside type="caution">
-If the response contains `"code": 8` with a message like `"Object kind endpoint has exhausted limits(500)"` or `"Object kind origin_pool has exhausted limits"`, the tenant has hit its quota. Unlike healthchecks, origin pools are **required** for the demo — the demo cannot proceed without one. Delete unused origin pools from other namespaces to free capacity (deleting an origin pool also frees its endpoint sub-objects), then retry. If the limit cannot be resolved, contact your F5 XC administrator to increase the tenant quota.
+If the response contains `"code": 8` with a message like `"Object kind endpoint has exhausted limits(500)"` or `"Object kind origin_pool has exhausted limits"`, the tenant has hit its quota. Unlike healthchecks, origin pools are **required** for the demo — the demo cannot proceed without one. Delete unused origin pools from other namespaces to free capacity (deleting an origin pool also frees its endpoint sub-objects), then retry. If the limit cannot be resolved, contact your F5 Distributed Cloud (F5 XC) administrator to increase the tenant quota.
 </Aside>
 
 ### Verify Healthcheck is Linked

--- a/docs/api-automation/phase-4-teardown.mdx
+++ b/docs/api-automation/phase-4-teardown.mdx
@@ -120,7 +120,7 @@ curl -s -X GET \
 ```
 
 <Aside type="note">
-The individual GET endpoint (`/protected_domains/\{name\}`) may return "API Group could not be determined." If the DELETE endpoint returns the same error, use the list endpoint to verify that the domain no longer appears, or delete the protected domain through the F5 XC Console UI instead.
+The individual GET endpoint (`/protected_domains/\{name\}`) may return "API Group could not be determined." If the DELETE endpoint returns the same error, use the list endpoint to verify that the domain no longer appears, or delete the protected domain through the F5 Distributed Cloud (F5 XC) Console UI instead.
 </Aside>
 
 ## Phase 4 Evidence Summary

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -28,7 +28,7 @@ All curl examples use the `xTOKENx` placeholder format. Substitute with your env
 ## API Conventions
 
 <Aside type="note">
-These conventions apply to all F5 XC configuration and CSD API endpoints. Understanding them prevents common automation mistakes.
+These conventions apply to all F5 Distributed Cloud (F5 XC) configuration and CSD API endpoints. Understanding them prevents common automation mistakes.
 </Aside>
 
 ### Response Bodies

--- a/docs/diagnostics.mdx
+++ b/docs/diagnostics.mdx
@@ -110,7 +110,7 @@ dig +short _acme-challenge.xF5XC_DOMAINNAMEx TXT
 | Result | Meaning |
 | --- | --- |
 | **PASS** &mdash; CNAME to `*.autocerts.ves.volterra.io.` (external DNS) | ACME challenge CNAME is in place |
-| **PASS** &mdash; TXT record with domain value (F5 XC managed DNS) | Platform-managed ACME challenge via TXT record |
+| **PASS** &mdash; TXT record with domain value (F5 Distributed Cloud (F5 XC) managed DNS) | Platform-managed ACME challenge via TXT record |
 | **FAIL** &mdash; both empty | ACME record not configured; certificate will stay in `PreDomainChallengePending` |
 
 <Aside type="note">


### PR DESCRIPTION
## Summary

- Adds `F5 Distributed Cloud (F5 XC)` expansion on the **first occurrence** of `F5 XC` in each of the four affected files
- All subsequent uses of the abbreviation within each file are left unchanged
- No prose restructuring — each change is a single targeted in-place substitution

## Files changed

| File | Location | Change |
|------|----------|--------|
| `docs/diagnostics.mdx` | L113 — table cell | `F5 XC managed DNS` → `F5 Distributed Cloud (F5 XC) managed DNS` |
| `docs/api-reference.mdx` | L31 — Aside text | `all F5 XC configuration` → `all F5 Distributed Cloud (F5 XC) configuration` |
| `docs/api-automation/phase-1-build.mdx` | L150 — Aside text | `your F5 XC administrator` → `your F5 Distributed Cloud (F5 XC) administrator` |
| `docs/api-automation/phase-4-teardown.mdx` | L123 — Aside text | `the F5 XC Console UI` → `the F5 Distributed Cloud (F5 XC) Console UI` |

## Test plan

- [ ] Confirm the four changed lines render correctly in the docs site
- [ ] Confirm no MDX syntax errors (no braces, bare `<`, or component changes introduced)
- [ ] Confirm CI passes

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)