### PR TITLE
docs: preserve HTTPS LB during teardown to avoid Let's Encrypt rate limits

### DIFF
--- a/READINESS_MATRIX.md
+++ b/READINESS_MATRIX.md
@@ -67,7 +67,7 @@ not accessible.
    | `healthcheck` | 1 | No | 0 |
    | `origin_pool` | 1 | Yes | 1 |
    | `endpoint` | 1 | Yes | 1 |
-   | `http_loadbalancer` | 2 | Yes | 1 |
+   | `http_loadbalancer` | 2 (or 1 if HTTPS LB skeleton exists) | Yes | 1 |
 
    For each kind, the jq filter calculates:
    - `remaining = limit - usage` (unlimited if limit is `-1`)
@@ -87,7 +87,7 @@ not accessible.
    If creation returns error code `8`, record as FAIL. A `409`
    (domain already exists) counts as PASS.
 
-**Fallback: Probe-Based Quota Checks**
+### Fallback: Probe-Based Quota Checks
 
 If PF-T1-0 fails (403, 404, or unexpected format), fall back to
 probe-and-delete for all object kinds. Create and immediately
@@ -155,12 +155,31 @@ never respond to connectivity tests.
 Executes auto-teardown if leftover objects are found. The pre-flight
 check computes a deterministic `{objects, any_infra_exists,
 any_csd_exists, status, action}` object via jq. The `status` field
-is one of: CLEAN, ALL_EXIST, TEARDOWN_NEEDED, or MITIGATIONS_ONLY.
+is one of: CLEAN, HTTPS_SKELETON, ALL_EXIST, TEARDOWN_NEEDED, or
+MITIGATIONS_ONLY.
+
+- `CLEAN` — all objects return 404, all counts are 0.
+- `HTTPS_SKELETON` — only the HTTPS LB exists and it is in skeleton
+  state (empty `default_route_pools`, no `client_side_defense`). All
+  other infra objects (HTTP LB, origin pool, healthcheck) return 404,
+  and CSD objects (protected domains, mitigated domains) have count 0.
+  This is a **clean-equivalent** state — the skeleton preserves the
+  Let's Encrypt certificate from a prior teardown. See
+  [Phase 4 — Teardown](/csd/api-automation/phase-4-teardown/) for why
+  the HTTPS LB is preserved.
+- `ALL_EXIST` — both HTTP LB and origin pool exist.
+- `TEARDOWN_NEEDED` — partial infra exists (not a skeleton).
+- `MITIGATIONS_ONLY` — only mitigated domains remain.
 
 16. Run the six pre-flight commands (HTTP LB, HTTPS LB, Origin Pool,
     Healthcheck, protected domains, mitigated domains). Capture each
     HTTP status code and domain count, then pipe all six through jq
-    to compute environment status deterministically.
+    to compute environment status deterministically. When the HTTPS LB
+    returns `200`, also fetch the full object body to determine if it
+    is a **skeleton** (empty `default_route_pools` and no
+    `client_side_defense`) or a fully-configured LB. This distinction
+    determines whether the status is `HTTPS_SKELETON`
+    (clean-equivalent) or `TEARDOWN_NEEDED`.
 17. Also check for stale probe objects from a prior interrupted
     pre-flight run — delete if found. These probes are only created
     when the Quota Usage API was unavailable and fallback
@@ -170,13 +189,19 @@ is one of: CLEAN, ALL_EXIST, TEARDOWN_NEEDED, or MITIGATIONS_ONLY.
     - `preflight-lb-probe` (HTTP load balancer)
     - `preflight-origin-probe` (origin pool)
     - `preflight-probe.example.com` (protected domain)
-18. **Auto-teardown if needed** — if `status` is not CLEAN (any
-    objects exist), run the full Phase 4 teardown by reading and
-    executing commands from `docs/api-automation/phase-4-teardown.mdx`.
-    No confirmation needed — Prepare is pre-meeting cleanup.
+18. **Auto-teardown if needed** — if `status` is not CLEAN and not
+    `HTTPS_SKELETON` (any non-skeleton objects exist), run the full
+    Phase 4 teardown by reading and executing commands from
+    `docs/api-automation/phase-4-teardown.mdx`. No confirmation
+    needed — Prepare is pre-meeting cleanup. If `status` is
+    `HTTPS_SKELETON`, no teardown is needed — the skeleton is
+    preserved by design and Phase 1 will restore it via PUT.
 19. **Re-run pre-flight** — execute the same pre-flight checks to
-    confirm `status` is CLEAN (`404` on all objects, counts are 0).
-    If any object still exists, report failure and stop.
+    confirm `status` is CLEAN or `HTTPS_SKELETON`. For CLEAN: `404`
+    on all objects, counts are 0. For `HTTPS_SKELETON`: HTTPS LB
+    returns `200` with skeleton state, all other objects return `404`,
+    counts are 0. If any unexpected object still exists, report
+    failure and stop.
 
 ### T5: Certificate Readiness
 
@@ -186,9 +211,11 @@ objects.
 20. **PF-T5-1: Recent Certificate Issuance History** — there is no
     API to query Let's Encrypt rate limits directly. Note as INFO
     that frequent create/destroy cycles can exhaust the weekly limit
-    (5 duplicate certificates per week per domain). If this demo
-    domain has been torn down and rebuilt multiple times recently,
-    include a warning that HTTPS may be rate-limited.
+    (5 duplicate certificates per exact identifier set per 7 days).
+    The default teardown behavior preserves the HTTPS LB as a skeleton
+    to avoid triggering new certificate requests. If the HTTPS LB was
+    fully deleted and rebuilt multiple times recently, include a
+    warning that HTTPS may be rate-limited.
 21. **PF-T5-2: Cert State** — captures HTTP code and response body.
     jq computes `{check, cert_state, status, detail}`:
     - HTTP `404` → SKIP (no HTTPS LB exists)
@@ -196,3 +223,10 @@ objects.
     - `AutoCertDomainRateLimited` → INFO (plan for HTTP-only)
     - `Pending`/`Started` → INFO (provisioning in progress)
     - All others → INFO with raw `cert_state` value
+
+    When the HTTPS LB exists as a skeleton from a prior teardown,
+    PF-T5-2 should still run and report the certificate state. A
+    `CertificateValid` result confirms the skeleton preservation
+    strategy is working — HTTPS will be available immediately after
+    Phase 1 restores the LB via PUT, with no Let's Encrypt
+    provisioning delay.

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -47,6 +47,18 @@ MD_COUNT=$(curl -s -H "Authorization: APIToken xF5XC_API_TOKENx" \
   "xF5XC_API_URLx/api/shape/csd/namespaces/xF5XC_NAMESPACEx/mitigated_domains" \
   | jq '[.items // [] | .[] | select(.metadata.name != null)] | length')
 
+# If HTTPS LB exists, fetch body to detect skeleton state
+HTTPS_IS_SKELETON="false"
+if [ "$HTTPS_LB" = "200" ]; then
+  HTTPS_LB_BODY=$(curl -s \
+    -H "Authorization: APIToken xF5XC_API_TOKENx" \
+    "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https")
+  HTTPS_IS_SKELETON=$(echo "$HTTPS_LB_BODY" | jq '
+    ((.spec.default_route_pools // []) | length == 0) and
+    (.spec.client_side_defense == null)
+  ')
+fi
+
 # Compute deterministic environment status
 jq -n \
   --argjson http_lb "$HTTP_LB" \
@@ -55,30 +67,33 @@ jq -n \
   --argjson hc "$HC" \
   --argjson pd "$PD_COUNT" \
   --argjson md "$MD_COUNT" \
+  --argjson https_skeleton "$HTTPS_IS_SKELETON" \
 '{
   objects: [
     { name: "http_lb",           http_code: $http_lb, exists: ($http_lb == 200) },
-    { name: "https_lb",          http_code: $https_lb, exists: ($https_lb == 200) },
+    { name: "https_lb",          http_code: $https_lb, exists: ($https_lb == 200), is_skeleton: $https_skeleton },
     { name: "origin_pool",       http_code: $origin, exists: ($origin == 200) },
     { name: "healthcheck",       http_code: $hc, exists: ($hc == 200) },
     { name: "protected_domains", count: $pd, exists: ($pd > 0) },
     { name: "mitigated_domains", count: $md, exists: ($md > 0) }
   ],
-  any_infra_exists: ($http_lb == 200 or $https_lb == 200 or $origin == 200 or $hc == 200),
+  any_infra_exists: ($http_lb == 200 or ($https_lb == 200 and ($https_skeleton | not)) or $origin == 200 or $hc == 200),
   any_csd_exists: ($pd > 0 or $md > 0),
   status: (
     if ($http_lb == 404 and $https_lb == 404 and $origin == 404 and $hc == 404 and $pd == 0 and $md == 0) then "CLEAN"
+    elif ($https_lb == 200 and $https_skeleton and $http_lb == 404 and $origin == 404 and $hc == 404 and $pd == 0 and $md == 0) then "HTTPS_SKELETON"
     elif ($http_lb == 200 and $origin == 200) then "ALL_EXIST"
-    elif ($http_lb == 200 or $https_lb == 200 or $origin == 200 or $hc == 200) then "TEARDOWN_NEEDED"
-    elif ($md > 0 and $http_lb == 404 and $https_lb == 404 and $origin == 404 and $hc == 404) then "MITIGATIONS_ONLY"
+    elif ($http_lb == 200 or ($https_lb == 200 and ($https_skeleton | not)) or $origin == 200 or $hc == 200) then "TEARDOWN_NEEDED"
+    elif ($md > 0 and $http_lb == 404 and ($https_lb == 404 or ($https_lb == 200 and $https_skeleton)) and $origin == 404 and $hc == 404) then "MITIGATIONS_ONLY"
     else "TEARDOWN_NEEDED"
     end
   ),
   action: (
     if ($http_lb == 404 and $https_lb == 404 and $origin == 404 and $hc == 404 and $pd == 0 and $md == 0) then "Proceed to Phase 1"
+    elif ($https_lb == 200 and $https_skeleton and $http_lb == 404 and $origin == 404 and $hc == 404 and $pd == 0 and $md == 0) then "Proceed to Phase 1 (HTTPS LB skeleton will be restored via PUT)"
     elif ($http_lb == 200 and $origin == 200) then "All Phase 1 objects exist — verify health, optionally skip to Phase 2"
-    elif ($http_lb == 200 or $https_lb == 200 or $origin == 200 or $hc == 200) then "Run Phase 4 Teardown first, then re-check"
-    elif ($md > 0 and $http_lb == 404 and $https_lb == 404 and $origin == 404 and $hc == 404) then "Delete mitigated domains inline, then proceed"
+    elif ($http_lb == 200 or ($https_lb == 200 and ($https_skeleton | not)) or $origin == 200 or $hc == 200) then "Run Phase 4 Teardown first, then re-check"
+    elif ($md > 0 and $http_lb == 404 and ($https_lb == 404 or ($https_lb == 200 and $https_skeleton)) and $origin == 404 and $hc == 404) then "Delete mitigated domains inline, then proceed"
     else "Run Phase 4 Teardown first, then re-check"
     end
   )

--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -269,7 +269,99 @@ If the response contains `"code": 8` with a message like `"Object kind http_load
 
 ### HTTPS Load Balancer (Secondary)
 
-This is the **secondary** load balancer. It uses `https_auto_cert` on port 443 with automatic Let's Encrypt certificate provisioning. This LB is optional for demo progression — if the certificate hits rate limits (`AutoCertDomainRateLimited`), the demo continues using the HTTP LB.
+This is the **secondary** load balancer. It uses `https_auto_cert` on port 443 with automatic Let's Encrypt certificate provisioning. Before creating it, check if a **skeleton HTTPS LB** exists from a previous teardown — if so, restore it via PUT instead of POST to preserve the existing Let's Encrypt certificate and avoid rate limits (5 duplicate certificates per exact identifier set per 7 days).
+
+**Check if the HTTPS LB already exists:**
+
+```bash
+HTTPS_CHECK=$(curl -s -o /dev/null -w '%\{http_code\}' \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https")
+```
+
+If `HTTPS_CHECK` is `200`, a skeleton HTTPS LB exists — use **Path A (PUT)**. If `404`, use **Path B (POST)**.
+
+#### Path A: Restore Skeleton via PUT (HTTPS LB exists)
+
+When a skeleton HTTPS LB exists from a prior teardown, restore the full configuration via PUT. This re-attaches the origin pool and re-enables CSD **without triggering a new Let's Encrypt certificate request** — the existing certificate remains valid.
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "metadata": {
+      "name": "xF5XC_LB_NAMEx-https",
+      "namespace": "xF5XC_NAMESPACEx",
+      "labels": {},
+      "annotations": {},
+      "description": "HTTPS LB with Client-Side Defense enabled (secondary, cert-dependent)",
+      "disable": false
+    },
+    "spec": {
+      "domains": ["xF5XC_DOMAINNAMEx"],
+      "https_auto_cert": {
+        "http_redirect": false,
+        "add_hsts": false,
+        "port": 443,
+        "default_header": {},
+        "enable_path_normalize": {},
+        "no_mtls": {},
+        "default_loadbalancer": {}
+      },
+      "advertise_on_public_default_vip": {},
+      "default_route_pools": [{
+        "pool": {
+          "namespace": "xF5XC_NAMESPACEx",
+          "name": "xF5XC_ORIGIN_POOLx",
+          "kind": "origin_pool"
+        },
+        "weight": 1,
+        "priority": 1
+      }],
+      "client_side_defense": {
+        "policy": {
+          "js_insert_all_pages": {}
+        }
+      },
+      "disable_rate_limit": {},
+      "no_service_policies": {},
+      "round_robin": {},
+      "disable_waf": {},
+      "no_challenge": {},
+      "disable_bot_defense": {},
+      "disable_api_definition": {},
+      "disable_api_discovery": {},
+      "disable_ip_reputation": {},
+      "disable_malicious_user_detection": {},
+      "single_lb_app": {
+        "disable_discovery": {},
+        "disable_ddos_detection": {},
+        "disable_malicious_user_detection": {}
+      },
+      "disable_trust_client_ip_headers": {},
+      "user_id_client_ip": {},
+      "disable_threat_mesh": {},
+      "l7_ddos_action_default": {},
+      "system_default_timeouts": {},
+      "default_sensitive_data_policy": {},
+      "disable_malware_protection": {},
+      "disable_api_testing": {}
+    }
+  }' \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https" \
+  | jq .
+```
+
+A `200` response confirms the skeleton was restored with the full configuration. The certificate state should remain `CertificateValid` — no new Let's Encrypt provisioning is triggered.
+
+<Aside type="note">
+**Skeleton restoration.** PUT replaces the entire object spec. The skeleton HTTPS LB retained its domain binding and certificate during teardown. This PUT restores the origin pool reference and re-enables Client-Side Defense without triggering a new Let's Encrypt certificate request. HTTPS is available immediately.
+</Aside>
+
+#### Path B: Create New via POST (HTTPS LB does not exist)
+
+When no HTTPS LB exists (first run or after a full teardown), create it via POST. This triggers Let's Encrypt certificate provisioning, which may take 5–10 minutes.
 
 ```bash
 curl -s -X POST \
@@ -339,10 +431,14 @@ curl -s -X POST \
   | jq .
 ```
 
-A `200` response confirms the HTTPS load balancer was created.
+A `200` response confirms the HTTPS load balancer was created. Certificate provisioning begins automatically.
 
 <Aside type="caution">
 If the response contains `"code": 8` with "exhausted limits", the HTTPS LB cannot be created. The HTTPS LB is optional — the demo proceeds using the HTTP LB. Note the quota limitation in the Phase 1 Evidence Summary as INFO.
+</Aside>
+
+<Aside type="note">
+**Let's Encrypt rate limits.** Creating a new HTTPS LB triggers a Let's Encrypt certificate request. Let's Encrypt allows only 5 duplicate certificates per exact identifier set per 7 days. If `cert_state` shows `AutoCertDomainRateLimited`, the demo continues using the HTTP LB. To avoid hitting this limit, the default teardown preserves the HTTPS LB as a skeleton — see [Phase 4 — Teardown](/csd/api-automation/phase-4-teardown/).
 </Aside>
 
 ### Evidence
@@ -381,8 +477,9 @@ curl -s \
 | `name` | `${F5XC_LB_NAME}-https` | PASS |
 | `domains` | Contains `F5XC_DOMAINNAME` | PASS |
 | `csd_enabled` | `true` | PASS — CSD is configured on this LB |
-| `state` | `VIRTUAL_HOST_PENDING_A_RECORD` | Expected at this point — DNS not yet configured |
-| `cert_state` | `PreDomainChallengePending` | Expected — ACME challenge not started. Informational only — does not block demo progression |
+| `creation_method` | PUT (restored skeleton) or POST (new) | INFO — PUT preserves existing certificate |
+| `state` | `VIRTUAL_HOST_READY` (PUT) or `VIRTUAL_HOST_PENDING_A_RECORD` (POST) | Expected — PUT path may already be READY since DNS persisted from skeleton |
+| `cert_state` | `CertificateValid` (PUT) or `PreDomainChallengePending` (POST) | PUT preserves existing cert; POST triggers new provisioning |
 
 ## Step 4: Configure DNS
 

--- a/docs/api-automation/phase-4-teardown.mdx
+++ b/docs/api-automation/phase-4-teardown.mdx
@@ -20,10 +20,10 @@ Phase 4 removes all objects created during the exercise in reverse dependency or
 Remove objects in **reverse creation order** — delete objects that depend on other objects first:
 
 1. **Mitigated Domains** — delete all CSD mitigated domains created in Phase 3
-2. **HTTPS Load Balancer** (`${F5XC_LB_NAME}-https`) — depends on Origin Pool
+2. **HTTPS Load Balancer** (`${F5XC_LB_NAME}-https`) — strip to skeleton (preserve Let's Encrypt certificate); full DELETE only on explicit request
 3. **HTTP Load Balancer** (`${F5XC_LB_NAME}-http`) — depends on Origin Pool
 4. **Origin Pool** — depends on Healthcheck (if created)
-5. **DNS zone cleanup** — managed records (A and ACME) auto-clean when the LBs are deleted; manual records in `default_rr_set_group` need manual cleanup via `PUT`
+5. **DNS zone cleanup** — the HTTPS LB skeleton retains its managed A and ACME records (this is desired — it keeps the certificate valid). The HTTP LB's managed records auto-clean on deletion. Manual records in `default_rr_set_group` need manual cleanup via `PUT`
 6. **Healthcheck** — only if created in Phase 1 Step 1
 7. **Protected Domain** — delete the CSD protected domain registration
 
@@ -56,9 +56,53 @@ curl -s \
 The mitigated domains list may return a phantom entry (count = 1) with null metadata after all mitigated domains are deleted. This is a backend artifact that appears when the CSD service state is between configurations — it does not represent a real mitigation and can be ignored. Attempting to delete this phantom entry returns `"Delete list when service not configured"`.
 </Aside>
 
-## Delete HTTPS Load Balancer
+## Strip HTTPS Load Balancer to Skeleton
 
-Delete the secondary HTTPS LB first:
+Instead of deleting the HTTPS LB, strip it to a **skeleton** state — remove the origin pool reference and CSD configuration while preserving the domain binding, `https_auto_cert` settings, and the Let's Encrypt certificate. This avoids triggering a new certificate request on the next demo run (Let's Encrypt enforces a limit of 5 duplicate certificates per exact identifier set per 7 days).
+
+**Step 1 — GET the current HTTPS LB config:**
+
+```bash
+HTTPS_LB_JSON=$(curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https")
+```
+
+**Step 2 — Strip to skeleton via jq and PUT back:**
+
+```bash
+echo "$HTTPS_LB_JSON" | jq '{
+  metadata: .metadata,
+  spec: (.spec | del(.client_side_defense) | .disable_client_side_defense = {} | .default_route_pools = [])
+}' | curl -s -X PUT \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  -H "Content-Type: application/json" \
+  -d @- \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https" \
+  | jq .
+```
+
+The jq filter preserves the entire spec (domains, `https_auto_cert`, `advertise_on_public_default_vip`, and all disabled feature flags) while removing `client_side_defense` (replaced with `disable_client_side_defense: {}`) and clearing `default_route_pools` to an empty array. The certificate and DNS bindings remain intact.
+
+**Verify** the HTTPS LB is now a skeleton:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https" \
+  | jq '{
+    name: .metadata.name,
+    domains: .spec.domains,
+    has_origin_pools: ((.spec.default_route_pools // []) | length > 0),
+    has_csd: (.spec.client_side_defense != null),
+    cert_state: .spec.cert_state
+  }'
+```
+
+Expected: `has_origin_pools: false`, `has_csd: false`, `domains` still populated, `cert_state` unchanged (e.g., `CertificateValid`).
+
+<Aside type="tip">
+**Full teardown option.** To completely delete the HTTPS LB (e.g., when decommissioning the demo domain permanently or when the operator explicitly requests "full teardown" or "force delete"), use the DELETE command instead:
 
 ```bash
 curl -s -X DELETE \
@@ -66,7 +110,8 @@ curl -s -X DELETE \
   "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https"
 ```
 
-Verify: `GET /api/config/namespaces/\{namespace\}/http_loadbalancers` should not contain `${F5XC_LB_NAME}-https`. If the object still appears in the list after DELETE returned `200`, wait 30 seconds and re-check once. If still present after the second check, report to operator — do not proceed.
+Only use full DELETE when the domain will not be reused within 7 days, or when explicitly requested. Deleting the HTTPS LB triggers a new Let's Encrypt certificate request on the next demo run.
+</Aside>
 
 ## Delete HTTP Load Balancer
 
@@ -128,7 +173,7 @@ The individual GET endpoint (`/protected_domains/\{name\}`) may return "API Grou
 | Object | Delete Status | Verify Status |
 | --- | --- | --- |
 | Mitigated Domains (6) | All `200` (empty `\{\}`) or skipped if Phase 3 not run | Count 0 (or 1 phantom) — PASS |
-| HTTPS Load Balancer (`-https`) | `200` (empty `\{\}`) | Not in list — PASS |
+| HTTPS Load Balancer (`-https`) | `200` (skeleton PUT) | Skeleton verified: no origin pools, no CSD, domains/cert intact — PASS |
 | HTTP Load Balancer (`-http`) | `200` (empty `\{\}`) | Not in list — PASS |
 | Origin Pool | `200` (empty `\{\}`) | Not in list — PASS |
 | Healthcheck | `200` (empty `\{\}`) or skipped | Not in list — PASS |
@@ -137,4 +182,4 @@ The individual GET endpoint (`/protected_domains/\{name\}`) may return "API Grou
 
 ---
 
-**Teardown complete.** All deployment objects have been removed. The DNS zone and its non-managed records remain intact.
+**Teardown complete.** All deployment objects have been removed except the HTTPS LB skeleton, which preserves the Let's Encrypt certificate and domain binding for the next demo run. The DNS zone and its non-managed records remain intact.


### PR DESCRIPTION
## Summary

- Update Phase 4 Teardown to strip the HTTPS LB to a skeleton configuration (preserving the certificate) instead of deleting it, avoiding Let's Encrypt duplicate certificate rate limits (5 per 7 days)
- Update Phase 1 Build to detect skeleton HTTPS LBs and restore them via PUT instead of creating new ones via POST
- Update pre-flight readiness check to recognize `HTTPS_SKELETON` as a clean-equivalent environment state

Closes #382

## Test plan

- [ ] CI checks pass
- [ ] Verify teardown leaves HTTPS LB in skeleton state with certificate preserved
- [ ] Verify build phase detects skeleton and restores via PUT
- [ ] Verify pre-flight check recognizes HTTPS_SKELETON status
- [ ] Confirm no Let's Encrypt rate limit errors after multiple demo cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)