### PR TITLE
feat: add conditional namespace creation and teardown logic

### DIFF
--- a/PRODUCT_EXPERTISE.md
+++ b/PRODUCT_EXPERTISE.md
@@ -109,6 +109,18 @@ Authorization: APIToken <token>
 
 **LB API:** `/api/config/namespaces/{namespace}/http_loadbalancers/{name}`
 
+**Namespace API:** `/api/web/namespaces/`
+
+| Operation | Method | Path | Body |
+| --------- | ------ | ---- | ---- |
+| List namespaces | `GET` | `/api/web/namespaces` | — |
+| Get namespace | `GET` | `/api/web/namespaces/{name}` | — |
+| Create namespace | `POST` | `/api/web/namespaces` | `{"metadata": {"name": "..."}, "spec": {}}` |
+| Cascade delete namespace | `POST` | `/api/web/namespaces/{name}/cascade_delete` | `{"name": "..."}` |
+
+Note: The `spec` field is required for creation (empty `{}` is valid).
+Standard `DELETE` returns "Not Implemented" — use cascade delete.
+
 ## API Conventions
 
 - **POST** returns the created object as JSON

--- a/READINESS_MATRIX.md
+++ b/READINESS_MATRIX.md
@@ -25,8 +25,10 @@
 
 ### T0: Connectivity & Auth
 
-FAIL in any T0 check blocks all subsequent tiers. Each check captures
-the HTTP status code and pipes it through a jq filter that computes a
+FAIL in any T0 check blocks all subsequent tiers. WARN in T0 (e.g.,
+namespace does not exist) does **not** block — the demo can proceed
+and Phase 1 Step 0 will create the namespace. Each check captures the
+HTTP status code and pipes it through a jq filter that computes a
 deterministic `{check, http_code, status, detail}` object — no
 operator interpretation required.
 
@@ -37,11 +39,13 @@ operator interpretation required.
 2. **PF-T0-2: Namespace Access** — GET
    `/api/config/namespaces/{namespace}/http_loadbalancers`. jq
    computes: `200` → PASS, `403` → FAIL (missing role binding),
-   `404` → FAIL (namespace does not exist), all others → FAIL.
+   `404` → WARN (namespace does not exist — will be created in
+   Phase 1 Step 0), all others → FAIL.
 3. **PF-T0-3: CSD API Access** — GET
    `/api/shape/csd/namespaces/{namespace}/status`. jq computes:
-   `200` → PASS, `403` → FAIL (missing CSD role binding), all
-   others → FAIL.
+   `200` → PASS, `403` → FAIL (missing CSD role binding), `404`
+   → WARN (namespace does not exist — CSD access will be verified
+   after namespace creation in Phase 1), all others → FAIL.
 
 ### T1: Quotas & Capacity
 
@@ -151,6 +155,10 @@ never respond to connectivity tests.
     WARN deterministically.
 
 ### T4: Environment Clean
+
+If PF-T0-2 returned `404` (namespace does not exist), skip T4 and
+report status as `CLEAN` — a non-existent namespace cannot contain
+leftover objects.
 
 Executes auto-teardown if leftover objects are found. The pre-flight
 check computes a deterministic `{objects, any_infra_exists,

--- a/docs/api-automation/index.mdx
+++ b/docs/api-automation/index.mdx
@@ -182,11 +182,16 @@ HTTP_CODE=$(curl -s -o /dev/null -w '%\{http_code\}' \
 echo "{\"http_code\": $HTTP_CODE}" | jq '{
   check: "PF-T0-2",
   http_code: .http_code,
-  status: (if .http_code == 200 then "PASS" else "FAIL" end),
+  status: (
+    if .http_code == 200 then "PASS"
+    elif .http_code == 404 then "WARN"
+    else "FAIL"
+    end
+  ),
   detail: (
     if .http_code == 200 then "Token has namespace access"
     elif .http_code == 403 then "Token lacks permissions for namespace — check role bindings"
-    elif .http_code == 404 then "Namespace does not exist"
+    elif .http_code == 404 then "Namespace does not exist — will be created in Phase 1 Step 0"
     else "Unexpected HTTP \(.http_code)"
     end
   )
@@ -202,10 +207,16 @@ HTTP_CODE=$(curl -s -o /dev/null -w '%\{http_code\}' \
 echo "{\"http_code\": $HTTP_CODE}" | jq '{
   check: "PF-T0-3",
   http_code: .http_code,
-  status: (if .http_code == 200 then "PASS" else "FAIL" end),
+  status: (
+    if .http_code == 200 then "PASS"
+    elif .http_code == 404 then "WARN"
+    else "FAIL"
+    end
+  ),
   detail: (
     if .http_code == 200 then "Token has CSD/Shape API permissions"
     elif .http_code == 403 then "Token lacks CSD role binding — contact tenant administrator"
+    elif .http_code == 404 then "Namespace does not exist — CSD access will be verified after namespace creation in Phase 1"
     else "Unexpected HTTP \(.http_code)"
     end
   )
@@ -697,6 +708,10 @@ T4 is about object-level cleanup: whether API objects that would
 conflict with Phase 1 creation still exist. It does not test IP
 addresses, network connectivity, or origin health (those concerns
 belong to T3).
+
+<Aside type="note">
+**Skip T4 when namespace does not exist.** If PF-T0-2 returned `404` (namespace does not exist), skip the T4 environment check entirely and report status as `CLEAN`. A non-existent namespace cannot contain leftover objects. Phase 1 Step 0 will create the namespace before any objects are created.
+</Aside>
 
 Run the six pre-flight commands from the [Pre-flight Check](#pre-flight-check) section above. Apply the [Decision Logic](#decision-logic) to determine next steps. If objects exist, auto-teardown is performed during Prepare stage (no confirmation needed).
 

--- a/docs/api-automation/phase-1-build.mdx
+++ b/docs/api-automation/phase-1-build.mdx
@@ -9,6 +9,46 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 
 Phase 1 deploys and validates the full CSD infrastructure. Complete all steps in order — each step must PASS before proceeding. Return to the [index](/csd/api-automation/) to complete Environment Setup and variable resolution before running these commands.
 
+## Step 0: Check & Create Namespace (Conditional)
+
+Check if the target namespace already exists on the tenant. If it does not exist, create it. Track the result in the `NAMESPACE_CREATED` shell variable — Phase 4 teardown uses this to decide whether to delete the namespace.
+
+```bash
+NS_CHECK=$(curl -s -o /dev/null -w '%\{http_code\}' \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/web/namespaces/xF5XC_NAMESPACEx")
+
+NAMESPACE_CREATED="false"
+if [ "$NS_CHECK" = "404" ]; then
+  curl -s -X POST \
+    -H "Authorization: APIToken xF5XC_API_TOKENx" \
+    -H "Content-Type: application/json" \
+    -d '{"metadata": {"name": "xF5XC_NAMESPACEx"}, "spec": {}}' \
+    "xF5XC_API_URLx/api/web/namespaces" | jq .
+  NAMESPACE_CREATED="true"
+fi
+```
+
+<Aside type="note">
+**The `spec` field is required.** The F5 XC namespace API requires a `spec` field in the request body even when no configuration is needed — pass an empty object `{}`. Omitting `spec` returns error code `3` ("spec should not be empty in request").
+</Aside>
+
+### Evidence
+
+Confirm the namespace exists and record whether it was created:
+
+```bash
+curl -s -o /dev/null -w '%\{http_code\}' \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/web/namespaces/xF5XC_NAMESPACEx"
+echo "NAMESPACE_CREATED=$NAMESPACE_CREATED"
+```
+
+| Field | Expected | Status |
+| --- | --- | --- |
+| HTTP Status | `200` | PASS if returned, FAIL if `404` or other |
+| `NAMESPACE_CREATED` | `true` (created) or `false` (pre-existing) | Informational — used by Phase 4 teardown |
+
 ## Step 1: Create Healthcheck (Optional)
 
 Create an HTTP healthcheck that the origin pool can use to monitor backend health.

--- a/docs/api-automation/phase-4-teardown.mdx
+++ b/docs/api-automation/phase-4-teardown.mdx
@@ -20,12 +20,13 @@ Phase 4 removes all objects created during the exercise in reverse dependency or
 Remove objects in **reverse creation order** — delete objects that depend on other objects first:
 
 1. **Mitigated Domains** — delete all CSD mitigated domains created in Phase 3
-2. **HTTPS Load Balancer** (`${F5XC_LB_NAME}-https`) — strip to skeleton (preserve Let's Encrypt certificate); full DELETE only on explicit request
+2. **HTTPS Load Balancer** (`${F5XC_LB_NAME}-https`) — strip to skeleton (preserve Let's Encrypt certificate); full DELETE if `NAMESPACE_CREATED=true` or on explicit request
 3. **HTTP Load Balancer** (`${F5XC_LB_NAME}-http`) — depends on Origin Pool
 4. **Origin Pool** — depends on Healthcheck (if created)
 5. **DNS zone cleanup** — the HTTPS LB skeleton retains its managed A and ACME records (this is desired — it keeps the certificate valid). The HTTP LB's managed records auto-clean on deletion. Manual records in `default_rr_set_group` need manual cleanup via `PUT`
 6. **Healthcheck** — only if created in Phase 1 Step 1
 7. **Protected Domain** — delete the CSD protected domain registration
+8. **Namespace** — only if created during Phase 1 Step 0 (`NAMESPACE_CREATED=true`)
 
 <Aside type="caution">
 **Do not delete the DNS zone.** The DNS zone is shared infrastructure supporting many other DNS records across the platform and should never be deleted. Only clean up records you added manually to the `default_rr_set_group`. The protected domain, however, is a CSD configuration object tied to this deployment and **should** be deleted when fully tearing down.
@@ -56,9 +57,16 @@ curl -s \
 The mitigated domains list may return a phantom entry (count = 1) with null metadata after all mitigated domains are deleted. This is a backend artifact that appears when the CSD service state is between configurations — it does not represent a real mitigation and can be ignored. Attempting to delete this phantom entry returns `"Delete list when service not configured"`.
 </Aside>
 
-## Strip HTTPS Load Balancer to Skeleton
+## HTTPS Load Balancer
 
-Instead of deleting the HTTPS LB, strip it to a **skeleton** state — remove the origin pool reference and CSD configuration while preserving the domain binding, `https_auto_cert` settings, and the Let's Encrypt certificate. This avoids triggering a new certificate request on the next demo run (Let's Encrypt enforces a limit of 5 duplicate certificates per exact identifier set per 7 days).
+The HTTPS LB teardown behavior depends on whether the namespace was created during this demo session (`NAMESPACE_CREATED` variable from Phase 1 Step 0):
+
+- **`NAMESPACE_CREATED=false`** (pre-existing namespace) — strip to **skeleton** state, preserving the Let's Encrypt certificate for reuse
+- **`NAMESPACE_CREATED=true`** (namespace created during demo) — **full DELETE**, since the namespace itself will be deleted and the certificate cannot be preserved
+
+### Path A: Strip to Skeleton (Pre-existing Namespace)
+
+When the namespace is pre-existing, strip the HTTPS LB to a **skeleton** state — remove the origin pool reference and CSD configuration while preserving the domain binding, `https_auto_cert` settings, and the Let's Encrypt certificate. This avoids triggering a new certificate request on the next demo run (Let's Encrypt enforces a limit of 5 duplicate certificates per exact identifier set per 7 days).
 
 **Step 1 — GET the current HTTPS LB config:**
 
@@ -101,8 +109,9 @@ curl -s \
 
 Expected: `has_origin_pools: false`, `has_csd: false`, `domains` still populated, `cert_state` unchanged (e.g., `CertificateValid`).
 
-<Aside type="tip">
-**Full teardown option.** To completely delete the HTTPS LB (e.g., when decommissioning the demo domain permanently or when the operator explicitly requests "full teardown" or "force delete"), use the DELETE command instead:
+### Path B: Full Delete (Namespace Created During Demo)
+
+When the namespace was created during this demo session, the HTTPS LB must be fully deleted — skeleton preservation is unnecessary because the namespace itself will be removed at the end of teardown.
 
 ```bash
 curl -s -X DELETE \
@@ -110,7 +119,10 @@ curl -s -X DELETE \
   "xF5XC_API_URLx/api/config/namespaces/xF5XC_NAMESPACEx/http_loadbalancers/xF5XC_LB_NAMEx-https"
 ```
 
-Only use full DELETE when the domain will not be reused within 7 days, or when explicitly requested. Deleting the HTTPS LB triggers a new Let's Encrypt certificate request on the next demo run.
+Verify: `GET /api/config/namespaces/\{namespace\}/http_loadbalancers` should not contain `${F5XC_LB_NAME}-https`.
+
+<Aside type="tip">
+**Full teardown option (pre-existing namespace).** Even when the namespace is pre-existing, you can fully delete the HTTPS LB if decommissioning the demo domain permanently or if the operator explicitly requests "full teardown" or "force delete". Only use full DELETE when the domain will not be reused within 7 days. Deleting the HTTPS LB triggers a new Let's Encrypt certificate request on the next demo run.
 </Aside>
 
 ## Delete HTTP Load Balancer
@@ -168,18 +180,51 @@ curl -s -X GET \
 The individual GET endpoint (`/protected_domains/\{name\}`) may return "API Group could not be determined." If the DELETE endpoint returns the same error, use the list endpoint to verify that the domain no longer appears, or delete the protected domain through the F5 Distributed Cloud (F5 XC) Console UI instead.
 </Aside>
 
+## Delete Namespace (Conditional)
+
+This step runs **only** if the namespace was created during Phase 1 Step 0 (`NAMESPACE_CREATED=true`). If the namespace was pre-existing (`NAMESPACE_CREATED=false`), skip this step entirely — the namespace is shared infrastructure that must not be deleted.
+
+<Aside type="caution">
+**Cascade delete removes all namespace-scoped objects.** The cascade delete endpoint removes the namespace and every object within it. All infrastructure objects (load balancers, origin pools, healthchecks) should already be deleted by the preceding teardown steps. The cascade delete acts as a final cleanup to catch any remaining objects and remove the namespace itself.
+</Aside>
+
+```bash
+if [ "$NAMESPACE_CREATED" = "true" ]; then
+  curl -s -X POST \
+    -H "Authorization: APIToken xF5XC_API_TOKENx" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "xF5XC_NAMESPACEx"}' \
+    "xF5XC_API_URLx/api/web/namespaces/xF5XC_NAMESPACEx/cascade_delete" | jq .
+fi
+```
+
+<Aside type="note">
+The standard `DELETE /api/web/namespaces/{name}` endpoint returns `"Not Implemented"` (error code `12`). You **must** use the cascade delete endpoint (`POST .../cascade_delete`) to delete a namespace.
+</Aside>
+
+Verify: Confirm the namespace no longer exists:
+
+```bash
+curl -s -o /dev/null -w '%\{http_code\}' \
+  -H "Authorization: APIToken xF5XC_API_TOKENx" \
+  "xF5XC_API_URLx/api/web/namespaces/xF5XC_NAMESPACEx"
+```
+
+Expected: `404` if `NAMESPACE_CREATED=true`, `200` if `NAMESPACE_CREATED=false`.
+
 ## Phase 4 Evidence Summary
 
 | Object | Delete Status | Verify Status |
 | --- | --- | --- |
 | Mitigated Domains (6) | All `200` (empty `\{\}`) or skipped if Phase 3 not run | Count 0 (or 1 phantom) — PASS |
-| HTTPS Load Balancer (`-https`) | `200` (skeleton PUT) | Skeleton verified: no origin pools, no CSD, domains/cert intact — PASS |
+| HTTPS Load Balancer (`-https`) | `200` (skeleton PUT) or `200` (full DELETE if `NAMESPACE_CREATED=true`) | Skeleton verified or not in list — PASS |
 | HTTP Load Balancer (`-http`) | `200` (empty `\{\}`) | Not in list — PASS |
 | Origin Pool | `200` (empty `\{\}`) | Not in list — PASS |
 | Healthcheck | `200` (empty `\{\}`) or skipped | Not in list — PASS |
 | Protected Domain | `200` (empty `\{\}`) | Not in list — PASS |
 | DNS zone | NOT deleted (shared infra) | Zone still exists — PASS |
+| Namespace | `200` (cascade delete) if `NAMESPACE_CREATED=true`, skipped otherwise | `404` if deleted, `200` if preserved — PASS |
 
 ---
 
-**Teardown complete.** All deployment objects have been removed except the HTTPS LB skeleton, which preserves the Let's Encrypt certificate and domain binding for the next demo run. The DNS zone and its non-managed records remain intact.
+**Teardown complete.** When the namespace was pre-existing (`NAMESPACE_CREATED=false`), all deployment objects have been removed except the HTTPS LB skeleton, which preserves the Let's Encrypt certificate and domain binding for the next demo run. When the namespace was created during the demo (`NAMESPACE_CREATED=true`), all objects including the HTTPS LB and namespace have been fully deleted. The DNS zone and its non-managed records remain intact in both cases.


### PR DESCRIPTION
## Summary

- Add conditional namespace creation in Phase 1: check if namespace exists, create only if missing, and track provenance with a flag
- Update Phase 4 teardown to cascade delete namespace only when it was created during the demo; fully delete HTTPS LB instead of skeleton strip when namespace is demo-created
- Change pre-flight checks to treat missing namespace as WARN instead of FAIL since on-the-fly creation is now supported
- Add namespace API reference to product expertise documentation

Closes #384

## Test plan

- [ ] CI checks pass
- [ ] Verify Phase 1 correctly detects existing namespace and skips creation
- [ ] Verify Phase 1 creates namespace when missing and sets NAMESPACE_CREATED flag
- [ ] Verify Phase 4 cascade deletes namespace only when NAMESPACE_CREATED is true
- [ ] Verify Phase 4 fully deletes HTTPS LB when namespace was demo-created
- [ ] Verify pre-flight treats missing namespace as WARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)