### PR TITLE
docs: add missing index description for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Client-Side Defense
+description: Client-side defense demo for detecting and mitigating browser-based Magecart-style threats with F5 Distributed Cloud.
 hero:
   tagline: Client-side defense for browser-based threats.
   image:


### PR DESCRIPTION
## Summary

- Adds the missing `description:` field to the CSD hero index page (`docs/index.mdx`) frontmatter
- Required by the starlight-llms-txt plugin to properly generate the llms.txt hierarchy

Refs f5xc-salesdemos/xcsh#223
Closes #565

## Test plan

- [ ] CI checks pass
- [ ] Verify llms.txt generation includes the index page description after merge