### PR TITLE
fix(i18n): remove nested quotes from JSX alt attribute

### DIFF
--- a/docs/de/xc-configuration.mdx
+++ b/docs/de/xc-configuration.mdx
@@ -73,7 +73,7 @@ Die CSD-Konfigurationsseite (oben) registriert eine Domäne beim Reporting-Engin
 6. Bestätigen Sie, dass die Skripte vom Load Balancer injiziert wurden (sie sind nicht Teil des Anwendungsquelltexts)
 </Steps>
 
-<Screenshot light="/images/csd-injected-scripts-light.png" dark="/images/csd-injected-scripts-dark.png" alt="Injizierte Skripte auf der Registerkarte "Elements" von DevTools" />
+<Screenshot light="/images/csd-injected-scripts-light.png" dark="/images/csd-injected-scripts-dark.png" alt="Injizierte Skripte auf der Registerkarte Elements von DevTools" />
 
 Die CSD-Instrumentierungsskripte werden vom F5 XC-Load-Balancer injiziert — sie sind nicht Teil des Anwendungsquelltexts.
 


### PR DESCRIPTION
## Summary

Remove nested double quotes from `alt` attribute in `docs/de/xc-configuration.mdx:76`.

The translator output `alt="...Registerkarte "Elements" von..."` which breaks JSX parsing — the inner `"` terminates the attribute value.

## Test plan

- [ ] Build succeeds
- [ ] Pages deploy succeeds
- [ ] CSD site renders in all 13 locales

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)