### PR TITLE
chore: update org name from f5xc-salesdemos to f5-sales-demo

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -1,5 +1,5 @@
 {
-  "source_repo": "f5xc-salesdemos/docs-control",
+  "source_repo": "f5-sales-demo/docs-control",
   "skip_files": {
     "xcsh": [
       "biome.json",

--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -1,7 +1,7 @@
 {
   "repository": {
     "description": "F5 XC client-side defense",
-    "homepage": "https://f5xc-salesdemos.github.io/csd/"
+    "homepage": "https://f5-sales-demo.github.io/csd/"
   },
   "topics": ["f5xc"]
 }

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,5 +15,5 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]'
-    uses: f5xc-salesdemos/docs-control/.github/workflows/auto-merge.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/auto-merge.yml@main
     secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,5 +10,5 @@ permissions:
 jobs:
   call:
     if: github.actor == 'dependabot[bot]'
-    uses: f5xc-salesdemos/docs-control/.github/workflows/dependabot-auto-merge.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/dependabot-auto-merge.yml@main
     secrets: inherit

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -25,14 +25,14 @@ concurrency:
 
 jobs:
   enforce-settings:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/enforce-repo-settings.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@main
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:
       repo-settings-token: ${{ secrets.REPO_SETTINGS_TOKEN }}
 
   sync-files:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/sync-managed-files.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@main
     with:
       source_sha: ${{ inputs.source_sha || '' }}
     secrets:

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -19,4 +19,4 @@ concurrency:
 
 jobs:
   docs:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/github-pages-deploy.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   check:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/require-linked-issue.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/require-linked-issue.yml@main
     secrets: inherit

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   lint:
-    uses: f5xc-salesdemos/docs-control/.github/workflows/super-linter.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@main
     secrets: inherit

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   audit:
     # Read-only freshness audit — no secrets required.
-    uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@main

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 🌐 English |
-[日本語](https://f5xc-salesdemos.github.io/csd/ja/) |
-[한국어](https://f5xc-salesdemos.github.io/csd/ko/) |
-[简体中文](https://f5xc-salesdemos.github.io/csd/zh-cn/) |
-[繁體中文](https://f5xc-salesdemos.github.io/csd/zh-tw/) |
-[Español](https://f5xc-salesdemos.github.io/csd/es/) |
-[Português](https://f5xc-salesdemos.github.io/csd/pt-br/) |
-[Français](https://f5xc-salesdemos.github.io/csd/fr/) |
-[Deutsch](https://f5xc-salesdemos.github.io/csd/de/) |
-[Italiano](https://f5xc-salesdemos.github.io/csd/it/) |
-[العربية](https://f5xc-salesdemos.github.io/csd/ar/) |
-[हिन्दी](https://f5xc-salesdemos.github.io/csd/hi/) |
-[ไทย](https://f5xc-salesdemos.github.io/csd/th/)
+[日本語](https://f5-sales-demo.github.io/csd/ja/) |
+[한국어](https://f5-sales-demo.github.io/csd/ko/) |
+[简体中文](https://f5-sales-demo.github.io/csd/zh-cn/) |
+[繁體中文](https://f5-sales-demo.github.io/csd/zh-tw/) |
+[Español](https://f5-sales-demo.github.io/csd/es/) |
+[Português](https://f5-sales-demo.github.io/csd/pt-br/) |
+[Français](https://f5-sales-demo.github.io/csd/fr/) |
+[Deutsch](https://f5-sales-demo.github.io/csd/de/) |
+[Italiano](https://f5-sales-demo.github.io/csd/it/) |
+[العربية](https://f5-sales-demo.github.io/csd/ar/) |
+[हिन्दी](https://f5-sales-demo.github.io/csd/hi/) |
+[ไทย](https://f5-sales-demo.github.io/csd/th/)
 
 # Client-Side Defense
 
-[![GitHub Pages Deploy](https://github.com/f5xc-salesdemos/csd/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5xc-salesdemos/csd/actions/workflows/github-pages-deploy.yml)
-[![Repository Settings](https://github.com/f5xc-salesdemos/csd/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5xc-salesdemos/csd/actions/workflows/enforce-repo-settings.yml)
-[![License](https://img.shields.io/github/license/f5xc-salesdemos/csd)](LICENSE)
+[![GitHub Pages Deploy](https://github.com/f5-sales-demo/csd/actions/workflows/github-pages-deploy.yml/badge.svg)](https://github.com/f5-sales-demo/csd/actions/workflows/github-pages-deploy.yml)
+[![Repository Settings](https://github.com/f5-sales-demo/csd/actions/workflows/enforce-repo-settings.yml/badge.svg)](https://github.com/f5-sales-demo/csd/actions/workflows/enforce-repo-settings.yml)
+[![License](https://img.shields.io/github/license/f5-sales-demo/csd)](LICENSE)
 
 F5 XC client-side defense
 
 
 ## Documentation
 
-Full documentation is available at **[https://f5xc-salesdemos.github.io/csd/](https://f5xc-salesdemos.github.io/csd/)**.
+Full documentation is available at **[https://f5-sales-demo.github.io/csd/](https://f5-sales-demo.github.io/csd/)**.
 
 ## Contributing
 

--- a/SCREENSHOT-INSTRUCTIONS.md
+++ b/SCREENSHOT-INSTRUCTIONS.md
@@ -1559,7 +1559,7 @@ Both go in `docs/images/`. Example: `csd-dashboard-light.png`, `csd-dashboard-da
 Import the component and pass light/dark image paths:
 
 ```mdx
-import Screenshot from '@f5xc-salesdemos/docs-theme/components/Screenshot.astro';
+import Screenshot from '@f5-sales-demo/docs-theme/components/Screenshot.astro';
 
 {/* Both variants */}
 <Screenshot

--- a/docs/ar/attack-scripts.mdx
+++ b/docs/ar/attack-scripts.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 توفر هذه الصفحة مكتبة من نصوص محاكاة الهجوم مصنّفة حسب الفئة. كل نص عبارة عن دالة ذاتية التنفيذ (IIFE) مصممة للصق في وحدة تحكم DevTools بالمتصفح على تطبيق العرض التوضيحي. استخدم هذه النصوص لممارسة قدرات اكتشاف CSD المحددة أثناء عروض العملاء.
 

--- a/docs/ar/csd-console.mdx
+++ b/docs/ar/csd-console.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## لوحة المعلومات
 

--- a/docs/ar/demo-website.mdx
+++ b/docs/ar/demo-website.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## فتح تطبيق العرض التوضيحي
 

--- a/docs/ar/references.mdx
+++ b/docs/ar/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## أدلة العرض التوضيحي ذات الصلة
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/ar/telemetry-beacons.mdx
+++ b/docs/ar/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 يعمل قياس CSD عن بُعد في مرحلتين. أولاً، تُحمَّل نصوص الأدوات من خادم المصدر للتطبيق عبر طلبات **GET** قياسية — تقوم هذه النصوص بحقن شيفرة مراقبة CSD في الصفحة. يتبع نمط عنوان URL للنص التنسيق `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`، وإن كان المسار الدقيق يتفاوت حسب التوزيع. بمجرد التهيئة، تُرسل النصوص بصفة دورية بيانات القياس عن بُعد إلى F5 عبر طلبات **POST** تُعرف بـ**الإشارات (Beacons)**. تُرسَل هذه الإشارات إلى نطاقات جمع الإشارات التي تديرها F5 (`*.zeronaught.com`)، وليس إلى خادم المصدر للتطبيق.
 

--- a/docs/ar/trigger-detection.mdx
+++ b/docs/ar/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/ar/xc-configuration.mdx
+++ b/docs/ar/xc-configuration.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 تم تمكين CSD مسبقاً على تطبيق العرض التوضيحي. يعرض هذا القسم شاشات التهيئة.
 

--- a/docs/de/attack-scripts.mdx
+++ b/docs/de/attack-scripts.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 Diese Seite enthält eine nach Kategorien geordnete Bibliothek von Angriffssimulationsskripten. Jedes Skript ist eine selbstausführende Funktion (IIFE), die in der Browser-DevTools-Konsole der Demo-Anwendung eingefügt werden kann. Verwenden Sie diese Skripten, um während Kundendemos bestimmte CSD-Erkennungsfunktionen zu testen.
 

--- a/docs/de/csd-console.mdx
+++ b/docs/de/csd-console.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Dashboard
 

--- a/docs/de/demo-website.mdx
+++ b/docs/de/demo-website.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Demo-Anwendung öffnen
 

--- a/docs/de/references.mdx
+++ b/docs/de/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## Verwandte Demo-Leitfäden
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/de/telemetry-beacons.mdx
+++ b/docs/de/telemetry-beacons.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD-Telemetrie läuft in zwei Phasen ab. Zunächst werden Instrumentierungsskripte über Standard-**GET**-Anfragen vom Anwendungs-Ursprungsserver geladen — diese schleusen den Überwachungscode von CSD in die Seite ein. Das URL-Muster des Skripts folgt dem Format `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, wobei der genaue Pfad je nach Deployment variiert. Nach der Initialisierung senden die Skripte regelmäßig Telemetriedaten an F5 zurück, und zwar über **POST**-Anfragen, die als **Beacons** bezeichnet werden. Diese Beacons werden an von F5 betriebene Signal-Sammeldomänen (`*.zeronaught.com`) gesendet, nicht an den Anwendungs-Ursprungsserver.
 

--- a/docs/de/trigger-detection.mdx
+++ b/docs/de/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/de/xc-configuration.mdx
+++ b/docs/de/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD ist bereits in der Demo-Anwendung aktiviert. Dieser Abschnitt zeigt die Konfigurationsbildschirme.
 

--- a/docs/en/attack-scripts.mdx
+++ b/docs/en/attack-scripts.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 This page provides a library of attack simulation scripts organized by category. Each script is a self-executing function (IIFE) designed to paste into the browser DevTools Console on the demo application. Use these scripts to exercise specific CSD detection capabilities during customer demos.
 

--- a/docs/en/csd-console.mdx
+++ b/docs/en/csd-console.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Dashboard
 

--- a/docs/en/demo-website.mdx
+++ b/docs/en/demo-website.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Open the Demo Application
 

--- a/docs/en/references.mdx
+++ b/docs/en/references.mdx
@@ -55,8 +55,8 @@ sidebar:
 
 ## Related Demo Guides
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/en/telemetry-beacons.mdx
+++ b/docs/en/telemetry-beacons.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD telemetry operates in two phases. First, instrumentation scripts load from the application origin via standard **GET** requests — these inject CSD's monitoring code into the page. The script URL pattern follows the format `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, though the exact path varies by deployment. Once initialized, the scripts periodically send telemetry back to F5 via **POST** requests known as **beacons**. These beacons are sent to F5-operated signal collection domains (`*.zeronaught.com`), not to the application origin.
 

--- a/docs/en/trigger-detection.mdx
+++ b/docs/en/trigger-detection.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/en/xc-configuration.mdx
+++ b/docs/en/xc-configuration.mdx
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD is already enabled on the demo application. This section shows the configuration screens.
 

--- a/docs/es/attack-scripts.mdx
+++ b/docs/es/attack-scripts.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 Esta página proporciona una biblioteca de scripts de simulación de ataques organizados por categoría. Cada script es una función autoejecutada (IIFE) diseñada para pegarse en la Consola de DevTools del navegador en la aplicación de demostración. Utilice estos scripts para ejercitar capacidades específicas de detección de CSD durante demostraciones a clientes.
 

--- a/docs/es/csd-console.mdx
+++ b/docs/es/csd-console.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Panel de control
 

--- a/docs/es/demo-website.mdx
+++ b/docs/es/demo-website.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Abrir la aplicación de demostración
 

--- a/docs/es/references.mdx
+++ b/docs/es/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## Guías de demostración relacionadas
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/es/telemetry-beacons.mdx
+++ b/docs/es/telemetry-beacons.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 La telemetría de CSD opera en dos fases. Primero, los scripts de instrumentación se cargan desde el origen de la aplicación mediante solicitudes **GET** estándar — estos inyectan el código de supervisión de CSD en la página. El patrón de URL del script sigue el formato `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, aunque la ruta exacta varía según el despliegue. Una vez inicializados, los scripts envían telemetría periódicamente a F5 mediante solicitudes **POST** conocidas como **balizas**. Estas balizas se envían a dominios de recopilación de señales operados por F5 (`*.zeronaught.com`), no al origen de la aplicación.
 

--- a/docs/es/trigger-detection.mdx
+++ b/docs/es/trigger-detection.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/es/xc-configuration.mdx
+++ b/docs/es/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD ya está habilitado en la aplicación de demostración. Esta sección muestra las pantallas de configuración.
 

--- a/docs/fr/attack-scripts.mdx
+++ b/docs/fr/attack-scripts.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 Cette page fournit une bibliothèque de scripts de simulation d'attaque organisés par catégorie. Chaque script est une fonction auto-exécutante (IIFE) conçue pour être collée dans la console DevTools du navigateur sur l'application de démonstration. Utilisez ces scripts pour exercer des capacités de détection CSD spécifiques lors des démonstrations clients.
 

--- a/docs/fr/csd-console.mdx
+++ b/docs/fr/csd-console.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Tableau de bord
 

--- a/docs/fr/demo-website.mdx
+++ b/docs/fr/demo-website.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Ouvrir l'application de démonstration
 

--- a/docs/fr/references.mdx
+++ b/docs/fr/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## Guides de démonstration associés
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/fr/telemetry-beacons.mdx
+++ b/docs/fr/telemetry-beacons.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 La télémétrie CSD fonctionne en deux phases. Premièrement, les scripts d'instrumentation se chargent depuis l'origine de l'application via des requêtes **GET** standard — ils injectent le code de surveillance de CSD dans la page. Le format d'URL du script suit le modèle `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, bien que le chemin exact varie selon le déploiement. Une fois initialisés, les scripts envoient périodiquement des données de télémétrie à F5 via des requêtes **POST** appelées **balises**. Ces balises sont envoyées vers les domaines de collecte de signaux exploités par F5 (`*.zeronaught.com`), et non vers l'origine de l'application.
 

--- a/docs/fr/trigger-detection.mdx
+++ b/docs/fr/trigger-detection.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/fr/xc-configuration.mdx
+++ b/docs/fr/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 La Défense côté client (CSD) est déjà activée sur l'application de démonstration. Cette section présente les écrans de configuration.
 

--- a/docs/hi/attack-scripts.mdx
+++ b/docs/hi/attack-scripts.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 यह पृष्ठ श्रेणी के अनुसार व्यवस्थित अटैक सिमुलेशन स्क्रिप्ट की एक लाइब्रेरी प्रदान करता है। प्रत्येक स्क्रिप्ट एक स्वयं-निष्पादित फ़ंक्शन (IIFE) है जिसे डेमो एप्लिकेशन पर ब्राउज़र DevTools Console में पेस्ट करने के लिए डिज़ाइन किया गया है। ग्राहक डेमो के दौरान विशिष्ट CSD डिटेक्शन क्षमताओं का परीक्षण करने के लिए इन स्क्रिप्ट का उपयोग करें।
 

--- a/docs/hi/csd-console.mdx
+++ b/docs/hi/csd-console.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## डैशबोर्ड
 

--- a/docs/hi/demo-website.mdx
+++ b/docs/hi/demo-website.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## डेमो एप्लिकेशन खोलें
 

--- a/docs/hi/references.mdx
+++ b/docs/hi/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## संबंधित डेमो गाइड
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/hi/telemetry-beacons.mdx
+++ b/docs/hi/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD टेलीमेट्री दो चरणों में संचालित होती है। पहले, इंस्ट्रूमेंटेशन स्क्रिप्ट मानक **GET** अनुरोधों के माध्यम से एप्लिकेशन ऑरिजिन से लोड होती हैं — ये पेज में CSD के मॉनिटरिंग कोड को इंजेक्ट करती हैं। स्क्रिप्ट URL पैटर्न `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js` प्रारूप का अनुसरण करता है, हालाँकि सटीक पथ परिनियोजन के अनुसार भिन्न होता है। एक बार प्रारंभ होने के बाद, स्क्रिप्ट समय-समय पर **POST** अनुरोधों के माध्यम से F5 को टेलीमेट्री वापस भेजती हैं, जिन्हें **बीकन** कहा जाता है। ये बीकन F5-संचालित सिग्नल संग्रह डोमेन (`*.zeronaught.com`) को भेजे जाते हैं, न कि एप्लिकेशन ऑरिजिन सर्वर को।
 

--- a/docs/hi/trigger-detection.mdx
+++ b/docs/hi/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/hi/xc-configuration.mdx
+++ b/docs/hi/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD पहले से ही डेमो एप्लिकेशन पर सक्षम है। यह अनुभाग कॉन्फ़िगरेशन स्क्रीन दिखाता है।
 

--- a/docs/it/attack-scripts.mdx
+++ b/docs/it/attack-scripts.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 Questa pagina fornisce una libreria di script di simulazione di attacco organizzati per categoria. Ogni script è una funzione auto-eseguente (IIFE) progettata per essere incollata nella Console DevTools del browser sull'applicazione demo. Utilizzate questi script per esercitare specifiche capacità di rilevamento CSD durante le demo ai clienti.
 

--- a/docs/it/csd-console.mdx
+++ b/docs/it/csd-console.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Dashboard
 

--- a/docs/it/demo-website.mdx
+++ b/docs/it/demo-website.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Aprire l'applicazione demo
 

--- a/docs/it/references.mdx
+++ b/docs/it/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## Guide demo correlate
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/it/telemetry-beacons.mdx
+++ b/docs/it/telemetry-beacons.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 La telemetria CSD opera in due fasi. Prima, gli script di strumentazione vengono caricati dall'origine dell'applicazione tramite richieste **GET** standard — questi iniettano il codice di monitoraggio di CSD nella pagina. Il pattern dell'URL dello script segue il formato `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, sebbene il percorso esatto vari in base alla distribuzione. Una volta inizializzati, gli script inviano periodicamente dati di telemetria a F5 tramite richieste **POST** note come **beacon**. Questi beacon vengono inviati ai domini di raccolta segnali gestiti da F5 (`*.zeronaught.com`), non all'origine dell'applicazione.
 

--- a/docs/it/trigger-detection.mdx
+++ b/docs/it/trigger-detection.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/it/xc-configuration.mdx
+++ b/docs/it/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD è già abilitato sull'applicazione demo. Questa sezione mostra le schermate di configurazione.
 

--- a/docs/ja/attack-scripts.mdx
+++ b/docs/ja/attack-scripts.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 このページでは、カテゴリ別に整理された攻撃シミュレーションスクリプトのライブラリを提供しています。各スクリプトは即時実行関数（IIFE）形式であり、デモアプリケーション上のブラウザDevToolsコンソールに貼り付けて使用するよう設計されています。これらのスクリプトを使用して、顧客デモ中に特定のCSD検出機能を実行できます。
 

--- a/docs/ja/csd-console.mdx
+++ b/docs/ja/csd-console.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## ダッシュボード
 

--- a/docs/ja/demo-website.mdx
+++ b/docs/ja/demo-website.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## デモアプリケーションを開く
 

--- a/docs/ja/references.mdx
+++ b/docs/ja/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## 関連デモガイド
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/ja/telemetry-beacons.mdx
+++ b/docs/ja/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD テレメトリーは2つのフェーズで動作します。まず、計装スクリプトが標準の **GET** リクエストを介してアプリケーションのオリジンサーバーから読み込まれます — これにより CSD のモニタリングコードがページに注入されます。スクリプトの URL パターンは `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js` の形式に従いますが、正確なパスはデプロイメントによって異なります。初期化されると、スクリプトは定期的に **POST** リクエスト（**ビーコン**と呼ばれます）を介してテレメトリーを F5 に送信します。これらのビーコンはアプリケーションのオリジンサーバーではなく、F5 が運営するシグナル収集ドメイン（`*.zeronaught.com`）に送信されます。
 

--- a/docs/ja/trigger-detection.mdx
+++ b/docs/ja/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/ja/xc-configuration.mdx
+++ b/docs/ja/xc-configuration.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD はデモアプリケーション上ですでに有効化されています。このセクションでは設定画面を説明します。
 

--- a/docs/ko/attack-scripts.mdx
+++ b/docs/ko/attack-scripts.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 이 페이지는 카테고리별로 구성된 공격 시뮬레이션 스크립트 라이브러리를 제공합니다. 각 스크립트는 데모 애플리케이션의 브라우저 DevTools 콘솔에 붙여넣어 실행할 수 있도록 설계된 자기 실행 함수(IIFE)입니다. 이 스크립트를 사용하여 고객 데모 중 특정 CSD 탐지 기능을 테스트하십시오.
 

--- a/docs/ko/csd-console.mdx
+++ b/docs/ko/csd-console.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## 대시보드
 

--- a/docs/ko/demo-website.mdx
+++ b/docs/ko/demo-website.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## 데모 애플리케이션 열기
 

--- a/docs/ko/references.mdx
+++ b/docs/ko/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## 관련 데모 가이드
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/ko/telemetry-beacons.mdx
+++ b/docs/ko/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD 텔레메트리는 두 단계로 작동합니다. 첫째, 계측 스크립트가 표준 **GET** 요청을 통해 애플리케이션 오리진에서 로드되며, 이를 통해 CSD의 모니터링 코드가 페이지에 주입됩니다. 스크립트 URL 패턴은 `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js` 형식을 따르지만, 정확한 경로는 배포 방식에 따라 다를 수 있습니다. 초기화된 후, 스크립트는 주기적으로 **비콘**이라고 하는 **POST** 요청을 통해 F5로 텔레메트리를 전송합니다. 이 비콘은 애플리케이션 오리진이 아닌 F5가 운영하는 신호 수집 도메인(`*.zeronaught.com`)으로 전송됩니다.
 

--- a/docs/ko/trigger-detection.mdx
+++ b/docs/ko/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/ko/xc-configuration.mdx
+++ b/docs/ko/xc-configuration.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD는 데모 애플리케이션에서 이미 활성화되어 있습니다. 이 섹션에서는 구성 화면을 보여줍니다.
 

--- a/docs/pt-br/attack-scripts.mdx
+++ b/docs/pt-br/attack-scripts.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 Esta página fornece uma biblioteca de scripts de simulação de ataque organizados por categoria. Cada script é uma função auto-executável (IIFE) projetada para ser colada no Console do DevTools do navegador na aplicação de demonstração. Utilize esses scripts para exercitar capacidades específicas de detecção do CSD durante demonstrações a clientes.
 

--- a/docs/pt-br/csd-console.mdx
+++ b/docs/pt-br/csd-console.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Painel
 

--- a/docs/pt-br/demo-website.mdx
+++ b/docs/pt-br/demo-website.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## Abrir a Aplicação de Demonstração
 

--- a/docs/pt-br/references.mdx
+++ b/docs/pt-br/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## Guias de Demonstração Relacionados
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/pt-br/telemetry-beacons.mdx
+++ b/docs/pt-br/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 A telemetria do CSD opera em duas fases. Primeiro, os scripts de instrumentação são carregados a partir da origem da aplicação via requisições **GET** padrão — esses scripts injetam o código de monitoramento do CSD na página. O padrão de URL do script segue o formato `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js`, embora o caminho exato varie conforme a implantação. Uma vez inicializados, os scripts enviam periodicamente dados de telemetria para a F5 por meio de requisições **POST** conhecidas como **beacons**. Esses beacons são enviados para domínios de coleta de sinais operados pela F5 (`*.zeronaught.com`), e não para a origem da aplicação.
 

--- a/docs/pt-br/trigger-detection.mdx
+++ b/docs/pt-br/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/pt-br/xc-configuration.mdx
+++ b/docs/pt-br/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 O CSD já está habilitado na aplicação de demonstração. Esta seção apresenta as telas de configuração.
 

--- a/docs/th/attack-scripts.mdx
+++ b/docs/th/attack-scripts.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 หน้านี้จัดเตรียมไลบรารีสคริปต์จำลองการโจมตีที่จัดหมวดหมู่ตามประเภท สคริปต์แต่ละตัวเป็นฟังก์ชันที่ทำงานด้วยตัวเอง (IIFE) ที่ออกแบบมาเพื่อวางลงใน DevTools Console ของเบราว์เซอร์บนแอปพลิเคชันสาธิต ใช้สคริปต์เหล่านี้เพื่อทดสอบความสามารถในการตรวจจับของ CSD เฉพาะด้านระหว่างการสาธิตให้ลูกค้า
 

--- a/docs/th/csd-console.mdx
+++ b/docs/th/csd-console.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## แดชบอร์ด
 

--- a/docs/th/demo-website.mdx
+++ b/docs/th/demo-website.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## เปิดแอปพลิเคชันสาธิต
 

--- a/docs/th/references.mdx
+++ b/docs/th/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## คู่มือ Demo ที่เกี่ยวข้อง
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/th/telemetry-beacons.mdx
+++ b/docs/th/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD การวัดและส่งข้อมูลทางไกลทำงานใน 2 ระยะ ขั้นแรก สคริปต์เครื่องมือวัดจะโหลดจากแอปพลิเคชันเซิร์ฟเวอร์ต้นทางผ่านคำขอ **GET** มาตรฐาน ซึ่งจะฉีดโค้ดการตรวจสอบของ CSD เข้าสู่หน้าเพจ รูปแบบ URL ของสคริปต์เป็นไปตามรูปแบบ `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js` แม้ว่าพาธที่แน่นอนจะแตกต่างกันตามการปรับใช้งาน เมื่อเริ่มต้นแล้ว สคริปต์จะส่งข้อมูลการวัดและส่งข้อมูลทางไกลกลับไปยัง F5 เป็นระยะๆ ผ่านคำขอ **POST** ที่เรียกว่า **บีคอน** โดยบีคอนเหล่านี้จะถูกส่งไปยังโดเมนรวบรวมสัญญาณที่ดำเนินการโดย F5 (`*.zeronaught.com`) ไม่ใช่ไปยังแอปพลิเคชันเซิร์ฟเวอร์ต้นทาง
 

--- a/docs/th/trigger-detection.mdx
+++ b/docs/th/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/th/xc-configuration.mdx
+++ b/docs/th/xc-configuration.mdx
@@ -12,7 +12,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD ได้รับการเปิดใช้งานบนแอปพลิเคชันสาธิตแล้ว ส่วนนี้แสดงหน้าจอการกำหนดค่า
 

--- a/docs/zh-cn/attack-scripts.mdx
+++ b/docs/zh-cn/attack-scripts.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 本页提供按类别组织的攻击模拟脚本库。每个脚本均为自执行函数（IIFE），设计用于在演示应用程序的浏览器开发者工具控制台中粘贴运行。在客户演示过程中，使用这些脚本来演练特定的 CSD 检测能力。
 

--- a/docs/zh-cn/csd-console.mdx
+++ b/docs/zh-cn/csd-console.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## 仪表板
 

--- a/docs/zh-cn/demo-website.mdx
+++ b/docs/zh-cn/demo-website.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## 打开演示应用程序
 

--- a/docs/zh-cn/references.mdx
+++ b/docs/zh-cn/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## 相关演示指南
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/zh-cn/telemetry-beacons.mdx
+++ b/docs/zh-cn/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD 遥测分两个阶段运行。首先，检测脚本通过标准 **GET** 请求从应用程序源加载——这些请求将 CSD 的监控代码注入页面。脚本 URL 格式遵循 `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js` 的模式，但具体路径因部署方式而异。初始化完成后，脚本会定期通过 **POST** 请求（称为**信标**）将遥测数据发回 F5。这些信标发送至 F5 运营的信号采集域（`*.zeronaught.com`），而非应用程序源。
 

--- a/docs/zh-cn/trigger-detection.mdx
+++ b/docs/zh-cn/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/zh-cn/xc-configuration.mdx
+++ b/docs/zh-cn/xc-configuration.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD 已在演示应用程序上启用。本节展示相关配置界面。
 

--- a/docs/zh-tw/attack-scripts.mdx
+++ b/docs/zh-tw/attack-scripts.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 本頁提供依類別整理的攻擊模擬腳本庫。每個腳本均為自執行函式（IIFE），設計為可貼入示範應用程式的瀏覽器 DevTools 主控台中執行。請使用這些腳本在客戶示範期間測試特定的 CSD 偵測能力。
 

--- a/docs/zh-tw/csd-console.mdx
+++ b/docs/zh-tw/csd-console.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## 儀表板
 

--- a/docs/zh-tw/demo-website.mdx
+++ b/docs/zh-tw/demo-website.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 ## 開啟示範應用程式
 

--- a/docs/zh-tw/references.mdx
+++ b/docs/zh-tw/references.mdx
@@ -58,8 +58,8 @@ i18n:
 
 ## 相關示範指南
 
-- [WAF](https://f5xc-salesdemos.github.io/waf/)
-- [Bot Standard](https://f5xc-salesdemos.github.io/bot-standard/)
-- [Bot Advanced](https://f5xc-salesdemos.github.io/bot-advanced/)
-- [API Protection](https://f5xc-salesdemos.github.io/api-protection/)
-- [DDoS](https://f5xc-salesdemos.github.io/ddos/)
+- [WAF](https://f5-sales-demo.github.io/waf/)
+- [Bot Standard](https://f5-sales-demo.github.io/bot-standard/)
+- [Bot Advanced](https://f5-sales-demo.github.io/bot-advanced/)
+- [API Protection](https://f5-sales-demo.github.io/api-protection/)
+- [DDoS](https://f5-sales-demo.github.io/ddos/)

--- a/docs/zh-tw/telemetry-beacons.mdx
+++ b/docs/zh-tw/telemetry-beacons.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD 遙測分兩個階段運作。首先，檢測腳本透過標準 **GET** 請求從應用程式來源載入 — 這些腳本會將 CSD 的監控程式碼注入頁面。腳本 URL 格式遵循 `https://<collection-domain>/__imp_apg__/js/<tenant-script>.js` 的模式，但確切路徑因部署方式而異。初始化後，腳本會定期透過稱為**信標**的 **POST** 請求將遙測資料回傳至 F5。這些信標會傳送至 F5 所管理的訊號收集網域（`*.zeronaught.com`），而非應用程式來源。
 

--- a/docs/zh-tw/trigger-detection.mdx
+++ b/docs/zh-tw/trigger-detection.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 export const combinedScript = `// CSD Demo — Combined Detection Script
 // Triggers ALL CSD detection signals: field reads, script injection, exfiltration

--- a/docs/zh-tw/xc-configuration.mdx
+++ b/docs/zh-tw/xc-configuration.mdx
@@ -10,7 +10,7 @@ i18n:
 ---
 
 import { Aside, Steps } from "@astrojs/starlight/components";
-import Screenshot from "@f5xc-salesdemos/docs-theme/components/Screenshot.astro";
+import Screenshot from "@f5-sales-demo/docs-theme/components/Screenshot.astro";
 
 CSD 已在示範應用程式上啟用。本節說明設定畫面。
 

--- a/scripts/locale-lint.sh
+++ b/scripts/locale-lint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Detects hardcoded locale lists that should import from @f5xc-salesdemos/i18n-core.
+# Detects hardcoded locale lists that should import from @f5-sales-demo/i18n-core.
 # Run from any repo root: bash scripts/locale-lint.sh
 # Exit 0 = clean, Exit 1 = violations found.
 set -euo pipefail
@@ -30,7 +30,7 @@ check_pattern() {
     -E "$pattern" . 2>/dev/null |
     grep -vE "($EXCLUDE_DIRS)" |
     grep -vE "($EXCLUDE_FILES)" |
-    grep -vE "from\s+['\"]@f5xc-salesdemos/i18n-core" |
+    grep -vE "from\s+['\"]@f5-sales-demo/i18n-core" |
     grep -vE "i18n-core/(src|dist)/" ||
     true)
 
@@ -53,7 +53,7 @@ done
 echo ""
 if [ "$VIOLATIONS" -gt 0 ]; then
   echo "FAIL: Found $VIOLATIONS pattern(s) with hardcoded locale data."
-  echo "These should import from @f5xc-salesdemos/i18n-core instead."
+  echo "These should import from @f5-sales-demo/i18n-core instead."
   exit 1
 else
   echo "PASS: No hardcoded locale lists detected."


### PR DESCRIPTION
Closes #805

Updated 103 file(s) for org rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)