### PR TITLE
test: make consumer shell tests portable

### DIFF
--- a/tests/test-public-identifiers.sh
+++ b/tests/test-public-identifiers.sh
@@ -33,19 +33,19 @@ if origin not in ipaddress.ip_network("198.51.100.0/24"):
     raise SystemExit("FAIL: F5XC_ORIGIN_IP is not in the origin-role TEST-NET-2 range")
 PY
 
-rg --quiet '^\| `F5XC_ORIGIN_IP` \| \*\*Yes\*\* \| — \| `198\.51\.100\.10` \|$' \
+grep -Eq '^\| `F5XC_ORIGIN_IP` \| \*\*Yes\*\* \| — \| `198\.51\.100\.10` \|$' \
   DEMO_READINESS_MATRIX.md || {
   echo "FAIL: TEST-NET origin is not treated as a required override" >&2
   exit 1
 }
 
-if rg --quiet 'PF-T3-skip|then "SKIP"' docs/*/demo/index.mdx; then
+if grep -Eq 'PF-T3-skip|then "SKIP"' docs/*/demo/index.mdx; then
   echo "FAIL: a TEST-NET origin can bypass readiness checks" >&2
   exit 1
 fi
 
 for file in docs/*/demo/index.mdx; do
-  rg --quiet 'check: "PF-T3-origin-guard"' "$file" || {
+  grep -Eq 'check: "PF-T3-origin-guard"' "$file" || {
     echo "FAIL: $file lacks the TEST-NET origin guard" >&2
     exit 1
   }

--- a/tests/test-runtime-identity.sh
+++ b/tests/test-runtime-identity.sh
@@ -12,24 +12,24 @@ targets=(
 )
 
 unsafe='(credentials:[[:space:]]*harvested|data:[[:space:]]*(creds|data)|captured:[[:space:]]*existing|cookies:[[:space:]]*document\.cookie|key:[[:space:]]*e\.key|keys:[[:space:]]*keyBuffer|window\.location\.href|email[[:space:]]*\?[[:space:]]*email\.value|pw[[:space:]]*\?[[:space:]]*pw\.value|P@ssword123)'
-if rg --quiet "$unsafe" "${targets[@]}"; then
+if grep -Eq -- "$unsafe" "${targets[@]}"; then
   echo "FAIL: runtime demo content retains or exposes identity-bearing values" >&2
   exit 1
 fi
 
 for file in docs/*/attack-scripts.mdx; do
-  rg --quiet 'field_values_discarded: true' "$file" || {
+  grep -Eq 'field_values_discarded: true' "$file" || {
     echo "FAIL: $file lacks field-value discard markers" >&2
     exit 1
   }
-  rg --quiet 'key_values_discarded: true' "$file" || {
+  grep -Eq 'key_values_discarded: true' "$file" || {
     echo "FAIL: $file lacks key-value discard markers" >&2
     exit 1
   }
 done
 
 for file in docs/*/trigger-detection.mdx docs/*/demo/phase-2-attack.mdx; do
-  rg --quiet 'field_values_discarded: true' "$file" || {
+  grep -Eq 'field_values_discarded: true' "$file" || {
     echo "FAIL: $file lacks field-value discard markers" >&2
     exit 1
   }


### PR DESCRIPTION
## Summary

- replace the undeclared ripgrep dependency in consumer shell tests with runner-available `grep -E`
- retain the same public-identifier and runtime-identity assertions
- verify the focused tests with `/usr/bin:/bin` as `PATH`

Closes #951.