### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/config/self-hosted-runner-policy.json
+++ b/.github/config/self-hosted-runner-policy.json
@@ -12,7 +12,7 @@
   },
   "profiles": {
     "ubuntu-24.04": {
-      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:cbc2f6d8c2c037f5fb9703767d7ed49b146dd0df20effc30ae85bebd5f33aa6c",
+      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:d7a9689e88c89b5d1fa1792ed6fd68953359512eeeb0a2a7c98eafe29a3d329f",
       "labels": ["ubuntu-24.04"],
       "memory": "8g",
       "cpus": "4",
@@ -22,7 +22,7 @@
       "docker_socket": false
     },
     "ubuntu-24.04-secondary": {
-      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:cbc2f6d8c2c037f5fb9703767d7ed49b146dd0df20effc30ae85bebd5f33aa6c",
+      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:d7a9689e88c89b5d1fa1792ed6fd68953359512eeeb0a2a7c98eafe29a3d329f",
       "labels": ["ubuntu-24.04"],
       "memory": "8g",
       "cpus": "4",
@@ -32,7 +32,7 @@
       "docker_socket": false
     },
     "automation": {
-      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:cbc2f6d8c2c037f5fb9703767d7ed49b146dd0df20effc30ae85bebd5f33aa6c",
+      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:d7a9689e88c89b5d1fa1792ed6fd68953359512eeeb0a2a7c98eafe29a3d329f",
       "labels": ["automation"],
       "memory": "8g",
       "cpus": "4",
@@ -42,7 +42,7 @@
       "docker_socket": false
     },
     "ubuntu-22.04": {
-      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:cbc2f6d8c2c037f5fb9703767d7ed49b146dd0df20effc30ae85bebd5f33aa6c",
+      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:d7a9689e88c89b5d1fa1792ed6fd68953359512eeeb0a2a7c98eafe29a3d329f",
       "labels": ["ubuntu-22.04"],
       "memory": "8g",
       "cpus": "4",
@@ -52,7 +52,7 @@
       "docker_socket": false
     },
     "container-build": {
-      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:d7253128030110789e9df797e847ddd0298b15ea0c4c4c9546d53e1f8dacf208",
+      "image": "ghcr.io/f5-sales-demo/self-hosted-runner@sha256:cd92098e69d8d671bc5e96b9465187fd955fb1b2cc40275fb5aca3a9551c837e",
       "labels": ["container-build"],
       "memory": "16g",
       "cpus": "6",


### PR DESCRIPTION
Closes #1136

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/config/self-hosted-runner-policy.json